### PR TITLE
docs(contributing): add conventional commits guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,20 @@ go test ./...
    golangci-lint run
    ```
 
-4. **Commit your changes**:
-   - Use clear, descriptive commit messages
+4. **Commit your changes** using [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   <type>(<scope>): <description>
+   ```
+
+   **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
+
+   **Examples:**
+   ```bash
+   git commit -m "feat(smtp): add STARTTLS support"
+   git commit -m "fix(imap): resolve connection timeout"
+   git commit -m "docs(readme): update installation steps"
+   ```
+
    - Reference related issues: `Fixes #123`
 
 5. **Push and create a Pull Request**:


### PR DESCRIPTION
## Summary
- Added Conventional Commits guidelines to CONTRIBUTING.md
- Includes commit types and examples

## Changes
- Updated commit instructions section with conventional commit format
- Added examples for feat, fix, and docs types

## Testing
- [x] Documentation only change

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] No sensitive data in code