### PR TITLE
fix(imap): remove problematic read/write deadlines causing IDLE timeout

### DIFF
--- a/cmd/mailserver/main.go
+++ b/cmd/mailserver/main.go
@@ -476,16 +476,6 @@ var serveCmd = &cobra.Command{
 				imapConfig.TCPKeepalivePeriod = d
 			}
 		}
-		if cfg.Server.IMAP.ReadTimeout != "" {
-			if d, err := time.ParseDuration(cfg.Server.IMAP.ReadTimeout); err == nil {
-				imapConfig.ReadTimeout = d
-			}
-		}
-		if cfg.Server.IMAP.WriteTimeout != "" {
-			if d, err := time.ParseDuration(cfg.Server.IMAP.WriteTimeout); err == nil {
-				imapConfig.WriteTimeout = d
-			}
-		}
 		if cfg.Server.IMAP.MaxConnections > 0 {
 			imapConfig.MaxConnections = cfg.Server.IMAP.MaxConnections
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,6 @@ type ServerConfig struct {
 type IMAPConfig struct {
 	IdleKeepaliveInterval string `koanf:"idle_keepalive_interval"` // Keepalive interval during IDLE (default "3m")
 	TCPKeepalivePeriod    string `koanf:"tcp_keepalive_period"`    // TCP SO_KEEPALIVE period (default "60s")
-	ReadTimeout           string `koanf:"read_timeout"`            // Read timeout for stale connections (default "30m")
-	WriteTimeout          string `koanf:"write_timeout"`           // Write timeout for stale connections (default "5m")
 	MaxConnections        int    `koanf:"max_connections"`         // Maximum global IMAP connections (default 2000)
 	MaxConnectionsPerIP   int    `koanf:"max_connections_per_ip"`  // Maximum connections per IP (default 100)
 }
@@ -205,8 +203,6 @@ func DefaultConfig() *Config {
 			IMAP: IMAPConfig{
 				IdleKeepaliveInterval: "3m",
 				TCPKeepalivePeriod:    "60s",
-				ReadTimeout:           "30m",
-				WriteTimeout:          "5m",
 				MaxConnections:        2000,
 				MaxConnectionsPerIP:   100,
 			},
@@ -593,8 +589,6 @@ func (c *Config) validateIMAP() error {
 	imapTimeouts := map[string]string{
 		"server.imap.idle_keepalive_interval": imap.IdleKeepaliveInterval,
 		"server.imap.tcp_keepalive_period":    imap.TCPKeepalivePeriod,
-		"server.imap.read_timeout":            imap.ReadTimeout,
-		"server.imap.write_timeout":           imap.WriteTimeout,
 	}
 
 	for name, timeout := range imapTimeouts {

--- a/internal/imap/server.go
+++ b/internal/imap/server.go
@@ -17,11 +17,8 @@ import (
 
 // Default connection limits and keepalive settings for IMAP
 const (
-	defaultIMAPMaxConnections      = 2000
+	defaultIMAPMaxConnections = 2000
 	defaultIMAPMaxConnectionsPerIP = 100
-	defaultTCPKeepalivePeriod      = 60 * time.Second
-	defaultReadTimeout             = 30 * time.Minute
-	defaultWriteTimeout            = 5 * time.Minute
 )
 
 // limitedListener wraps a net.Listener with connection limits and keepalive settings
@@ -34,8 +31,6 @@ type limitedListener struct {
 	perIPMu            sync.Mutex
 	sem                chan struct{}
 	tcpKeepalivePeriod time.Duration
-	readTimeout        time.Duration
-	writeTimeout       time.Duration
 }
 
 // newLimitedListener creates a connection-limiting listener with keepalive settings
@@ -50,8 +45,6 @@ func newLimitedListener(l net.Listener, config *IMAPConfig) *limitedListener {
 		perIPConns:         make(map[string]int),
 		sem:                make(chan struct{}, config.MaxConnections),
 		tcpKeepalivePeriod: config.TCPKeepalivePeriod,
-		readTimeout:        config.ReadTimeout,
-		writeTimeout:       config.WriteTimeout,
 	}
 }
 
@@ -83,15 +76,8 @@ func (l *limitedListener) Accept() (net.Conn, error) {
 
 	atomic.AddInt64(&l.currentConns, 1)
 
-	// Wrap with deadline management for stale connection detection
-	wrappedConn := &deadlineConn{
-		Conn:         conn,
-		readTimeout:  l.readTimeout,
-		writeTimeout: l.writeTimeout,
-	}
-
 	return &limitedConn{
-		Conn:     wrappedConn,
+		Conn:     conn,
 		listener: l,
 		ip:       ip,
 	}, nil
@@ -156,27 +142,6 @@ func enableTCPKeepalive(conn net.Conn, period time.Duration) {
 	}
 }
 
-// deadlineConn wraps a net.Conn with automatic read/write deadline management.
-// This helps detect stale connections that stop responding.
-type deadlineConn struct {
-	net.Conn
-	readTimeout  time.Duration
-	writeTimeout time.Duration
-}
-
-func (c *deadlineConn) Read(b []byte) (int, error) {
-	if c.readTimeout > 0 {
-		c.Conn.SetReadDeadline(time.Now().Add(c.readTimeout))
-	}
-	return c.Conn.Read(b)
-}
-
-func (c *deadlineConn) Write(b []byte) (int, error) {
-	if c.writeTimeout > 0 {
-		c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
-	}
-	return c.Conn.Write(b)
-}
 
 // Maximum number of mailbox trackers to cache (prevents unbounded memory growth)
 const maxTrackerCacheSize = 5000
@@ -191,8 +156,6 @@ type trackerEntry struct {
 type IMAPConfig struct {
 	IdleKeepaliveInterval time.Duration
 	TCPKeepalivePeriod    time.Duration
-	ReadTimeout           time.Duration
-	WriteTimeout          time.Duration
 	MaxConnections        int
 	MaxConnectionsPerIP   int
 }
@@ -202,8 +165,6 @@ func DefaultIMAPConfig() *IMAPConfig {
 	return &IMAPConfig{
 		IdleKeepaliveInterval: 3 * time.Minute,
 		TCPKeepalivePeriod:    60 * time.Second,
-		ReadTimeout:           30 * time.Minute,
-		WriteTimeout:          5 * time.Minute,
 		MaxConnections:        2000,
 		MaxConnectionsPerIP:   100,
 	}


### PR DESCRIPTION
## Problem
The deadlineConn wrapper was setting read/write deadlines on every operation, which caused IDLE connections to timeout after ~7 minutes. Logs showed:
```
handling IDLE command: read tcp ... read: connection timed out
failed to read command: write tcp ... broken pipe
```

## Root Cause
Setting deadlines on every read/write operation interferes with IDLE which needs connections to stay open indefinitely while waiting for updates or client commands.

## Solution
Removed the deadlineConn wrapper and rely on TCP-level keepalive instead:
- **TCP SO_KEEPALIVE (60s default)**: Detects genuinely dead connections at OS level
- **No application-level timeouts**: Allows IDLE to work properly
- **Standard approach**: Most IMAP servers use this method

## Changes
- Remove deadlineConn wrapper struct and methods
- Remove Read/Write timeout config fields (no longer needed)
- Keep TCP-level keepalive (TCP SO_KEEPALIVE) enabled on all connections

This is a hotfix for PR #5 which was causing IDLE connections to drop.

## Testing
- [x] All IMAP tests pass
- [x] Build succeeds
- [x] Deploy and verify IDLE stays connected longer than 7 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)