### PR TITLE
fix: webhook retry worker + tighten file permissions

### DIFF
--- a/cmd/mailserver/main.go
+++ b/cmd/mailserver/main.go
@@ -2506,7 +2506,7 @@ func copyFile(src, dst string) error {
 	}
 	defer srcFile.Close()
 
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), 0750); err != nil {
 		return err
 	}
 
@@ -2635,7 +2635,7 @@ func extractTarGz(archivePath, destDir string) error {
 				return err
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0750); err != nil {
 				return err
 			}
 			outFile, err := os.Create(targetPath)

--- a/internal/admin/api_handlers_v2.go
+++ b/internal/admin/api_handlers_v2.go
@@ -1320,7 +1320,7 @@ func (s *Server) handleAPIBackupTrigger(w http.ResponseWriter, r *http.Request) 
 	// Create backup to the backups directory
 	dataDir := s.config.Storage.DataDir
 	backupDir := filepath.Join(dataDir, "backups")
-	os.MkdirAll(backupDir, 0755)
+	os.MkdirAll(backupDir, 0750)
 
 	filename := fmt.Sprintf("mailserver-backup-%s.tar.gz", time.Now().Format("2006-01-02-150405"))
 	backupPath := filepath.Join(backupDir, filename)
@@ -1496,12 +1496,12 @@ func (s *Server) handleAPIRestore(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if hdr.Typeflag == tar.TypeDir {
-			os.MkdirAll(targetPath, 0755)
+			os.MkdirAll(targetPath, 0750)
 			continue
 		}
 
 		// Ensure parent dir exists
-		os.MkdirAll(filepath.Dir(targetPath), 0755)
+		os.MkdirAll(filepath.Dir(targetPath), 0750)
 
 		outFile, err := os.Create(targetPath)
 		if err != nil {

--- a/internal/admin/api_handlers_v2.go
+++ b/internal/admin/api_handlers_v2.go
@@ -1320,7 +1320,11 @@ func (s *Server) handleAPIBackupTrigger(w http.ResponseWriter, r *http.Request) 
 	// Create backup to the backups directory
 	dataDir := s.config.Storage.DataDir
 	backupDir := filepath.Join(dataDir, "backups")
-	os.MkdirAll(backupDir, 0750)
+	if err := os.MkdirAll(backupDir, 0750); err != nil {
+		s.logger.Error("Failed to create backup directory", "path", backupDir, "error", err.Error())
+		s.jsonError(w, http.StatusInternalServerError, "Failed to prepare backup directory")
+		return
+	}
 
 	filename := fmt.Sprintf("mailserver-backup-%s.tar.gz", time.Now().Format("2006-01-02-150405"))
 	backupPath := filepath.Join(backupDir, filename)
@@ -1496,12 +1500,20 @@ func (s *Server) handleAPIRestore(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if hdr.Typeflag == tar.TypeDir {
-			os.MkdirAll(targetPath, 0750)
+			if mkErr := os.MkdirAll(targetPath, 0750); mkErr != nil {
+				s.logger.Error("Failed to create restore directory", "path", targetPath, "error", mkErr.Error())
+				s.jsonError(w, http.StatusInternalServerError, "Failed to restore backup")
+				return
+			}
 			continue
 		}
 
 		// Ensure parent dir exists
-		os.MkdirAll(filepath.Dir(targetPath), 0750)
+		if mkErr := os.MkdirAll(filepath.Dir(targetPath), 0750); mkErr != nil {
+			s.logger.Error("Failed to create restore parent directory", "path", filepath.Dir(targetPath), "error", mkErr.Error())
+			s.jsonError(w, http.StatusInternalServerError, "Failed to restore backup")
+			return
+		}
 
 		outFile, err := os.Create(targetPath)
 		if err != nil {

--- a/internal/admin/handlers.go
+++ b/internal/admin/handlers.go
@@ -3546,12 +3546,12 @@ func extractBackup(file *os.File, destDir string) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, 0755); err != nil {
+			if err := os.MkdirAll(targetPath, 0750); err != nil {
 				return err
 			}
 		case tar.TypeReg:
 			// Ensure parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0750); err != nil {
 				return err
 			}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,9 +32,10 @@ type Server struct {
 	queuePath    string
 
 	// New services for production features
-	idempotency *IdempotencyStore   // Redis-backed idempotency store
-	suppression *SuppressionService // Email suppression list
-	scheduler   *Scheduler          // Scheduled email processor
+	idempotency    *IdempotencyStore   // Redis-backed idempotency store
+	suppression    *SuppressionService // Email suppression list
+	scheduler      *Scheduler          // Scheduled email processor
+	webhookRetrier *WebhookRetryWorker // Background webhook retry worker
 }
 
 // NewServer creates a new API server
@@ -71,6 +72,9 @@ func NewServer(
 
 	// Initialize scheduler for scheduled emails
 	s.scheduler = NewScheduler(db, s, 30*time.Second)
+
+	// Initialize webhook retry worker for extended retry of failed deliveries
+	s.webhookRetrier = NewWebhookRetryWorker(db, s)
 
 	// Register delivery event handler for webhooks and auto-suppression
 	if deliveryEngine != nil {
@@ -142,6 +146,12 @@ func (s *Server) Start(listen string) error {
 		s.logger.Info("Email scheduler started")
 	}
 
+	// Start the webhook retry worker
+	if s.webhookRetrier != nil {
+		s.webhookRetrier.Start()
+		s.logger.Info("Webhook retry worker started")
+	}
+
 	// Start server in goroutine
 	serverErr := make(chan error, 1)
 	go func() {
@@ -179,6 +189,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		if s.scheduler != nil {
 			s.scheduler.Stop()
 			s.logger.Info("Email scheduler stopped")
+		}
+
+		// Stop the webhook retry worker
+		if s.webhookRetrier != nil {
+			s.webhookRetrier.Stop()
+			s.logger.Info("Webhook retry worker stopped")
 		}
 
 		if s.httpServer != nil {

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,6 +23,11 @@ const (
 	maxWebhookRetries     = 3
 	webhookMaxFailures    = 5
 	maxConcurrentWebhooks = 50 // Maximum concurrent webhook deliveries
+
+	// Extended retry settings for the background retry worker
+	webhookMaxRetryAttempts = 8              // Total attempts including initial 3
+	webhookRetryMaxAge      = 24 * time.Hour // Stop retrying after 24 hours
+	webhookRetryInterval    = 1 * time.Minute // How often the retry worker runs
 )
 
 // webhookSemaphore limits concurrent webhook deliveries to prevent goroutine explosion
@@ -389,4 +396,161 @@ func generateWebhookSecret() string {
 		return "whsec_" + fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 	return "whsec_" + hex.EncodeToString(b)
+}
+
+// =============================================================================
+// Webhook Retry Worker
+// =============================================================================
+
+// WebhookRetryWorker retries failed webhook deliveries with extended backoff.
+type WebhookRetryWorker struct {
+	db      *sql.DB
+	server  *Server
+	running int32
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
+}
+
+// NewWebhookRetryWorker creates a new webhook retry worker.
+func NewWebhookRetryWorker(db *sql.DB, server *Server) *WebhookRetryWorker {
+	return &WebhookRetryWorker{
+		db:     db,
+		server: server,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Start begins the retry worker.
+func (w *WebhookRetryWorker) Start() {
+	if !atomic.CompareAndSwapInt32(&w.running, 0, 1) {
+		return
+	}
+	w.wg.Add(1)
+	go w.run()
+}
+
+// Stop stops the retry worker.
+func (w *WebhookRetryWorker) Stop() {
+	if !atomic.CompareAndSwapInt32(&w.running, 1, 0) {
+		return
+	}
+	close(w.stopCh)
+	w.wg.Wait()
+}
+
+func (w *WebhookRetryWorker) run() {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(webhookRetryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.retryFailedDeliveries()
+		}
+	}
+}
+
+// webhookRetryBackoff returns the minimum age a failed delivery must have
+// before the next retry attempt. Backoff schedule:
+// attempt 4: 1 min, attempt 5: 5 min, attempt 6: 30 min, attempt 7: 2 hours, attempt 8: 8 hours
+func webhookRetryBackoff(attemptCount int) time.Duration {
+	switch {
+	case attemptCount <= 3:
+		return 1 * time.Minute
+	case attemptCount == 4:
+		return 5 * time.Minute
+	case attemptCount == 5:
+		return 30 * time.Minute
+	case attemptCount == 6:
+		return 2 * time.Hour
+	default:
+		return 8 * time.Hour
+	}
+}
+
+func (w *WebhookRetryWorker) retryFailedDeliveries() {
+	ctx := context.Background()
+	cutoff := time.Now().Add(-webhookRetryMaxAge)
+
+	// Find failed deliveries that are eligible for retry:
+	// - failed (success = FALSE)
+	// - not yet exhausted (attempt_count < max)
+	// - not too old (created_at > cutoff)
+	rows, err := w.db.QueryContext(ctx, `
+		SELECT wd.id, wd.webhook_id, wd.event_type, wd.payload, wd.attempt_count, wd.created_at,
+		       wh.url, wh.secret, wh.is_active
+		FROM webhook_deliveries wd
+		JOIN webhooks wh ON wd.webhook_id = wh.id
+		WHERE wd.success = FALSE
+		  AND wd.attempt_count < ?
+		  AND wd.created_at > ?
+		  AND wh.is_active = TRUE
+		  AND wh.failure_count < ?
+		ORDER BY wd.created_at ASC
+		LIMIT 50
+	`, webhookMaxRetryAttempts, cutoff, webhookMaxFailures)
+	if err != nil {
+		w.server.logger.Error("Failed to query failed webhook deliveries", "error", err.Error())
+		return
+	}
+	defer rows.Close()
+
+	type failedDelivery struct {
+		ID           int64
+		WebhookID    int64
+		EventType    string
+		Payload      string
+		AttemptCount int
+		CreatedAt    time.Time
+		URL          string
+		Secret       string
+	}
+
+	var deliveries []failedDelivery
+	for rows.Next() {
+		var d failedDelivery
+		var isActive bool
+		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.AttemptCount, &d.CreatedAt, &d.URL, &d.Secret, &isActive); err != nil {
+			continue
+		}
+		// Check backoff: only retry if enough time has passed since creation
+		backoff := webhookRetryBackoff(d.AttemptCount)
+		if time.Since(d.CreatedAt) < backoff {
+			continue
+		}
+		deliveries = append(deliveries, d)
+	}
+
+	for _, d := range deliveries {
+		signature := generateWebhookSignature([]byte(d.Payload), d.Secret)
+		respCode, respBody, err := w.server.sendWebhookRequest(d.URL, []byte(d.Payload), signature)
+
+		if err == nil && respCode >= 200 && respCode < 300 {
+			// Success — mark delivery as successful
+			w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET success = TRUE, response_code = ?, response_body = ?, attempt_count = ? WHERE id = ?`,
+				respCode, truncateString(respBody, 1000), d.AttemptCount+1, d.ID)
+			// Reset webhook failure count
+			w.db.ExecContext(ctx, `UPDATE webhooks SET failure_count = 0, last_success_at = ?, last_triggered_at = ? WHERE id = ?`,
+				time.Now(), time.Now(), d.WebhookID)
+			w.server.logger.Info("Webhook retry succeeded",
+				"delivery_id", d.ID, "webhook_id", d.WebhookID, "attempt", d.AttemptCount+1)
+		} else {
+			// Still failing — increment attempt count
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET attempt_count = ?, response_code = ?, response_body = ? WHERE id = ?`,
+				d.AttemptCount+1, respCode, truncateString(errMsg, 1000), d.ID)
+
+			if d.AttemptCount+1 >= webhookMaxRetryAttempts {
+				w.server.logger.Warn("Webhook delivery exhausted all retries",
+					"delivery_id", d.ID, "webhook_id", d.WebhookID, "attempts", d.AttemptCount+1)
+			}
+		}
+	}
 }

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -441,21 +441,30 @@ func (w *WebhookRetryWorker) Stop() {
 func (w *WebhookRetryWorker) run() {
 	defer w.wg.Done()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel context when stop signal received
+	go func() {
+		<-w.stopCh
+		cancel()
+	}()
+
 	ticker := time.NewTicker(webhookRetryInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-w.stopCh:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			w.retryFailedDeliveries()
+			w.retryFailedDeliveries(ctx)
 		}
 	}
 }
 
-// webhookRetryBackoff returns the minimum age a failed delivery must have
-// before the next retry attempt. Backoff schedule:
+// webhookRetryBackoff returns the minimum wait time before the next retry attempt.
+// Backoff schedule (from last attempt):
 // attempt 4: 1 min, attempt 5: 5 min, attempt 6: 30 min, attempt 7: 2 hours, attempt 8: 8 hours
 func webhookRetryBackoff(attemptCount int) time.Duration {
 	switch {
@@ -472,17 +481,15 @@ func webhookRetryBackoff(attemptCount int) time.Duration {
 	}
 }
 
-func (w *WebhookRetryWorker) retryFailedDeliveries() {
-	ctx := context.Background()
+func (w *WebhookRetryWorker) retryFailedDeliveries(ctx context.Context) {
 	cutoff := time.Now().Add(-webhookRetryMaxAge)
 
-	// Find failed deliveries that are eligible for retry:
-	// - failed (success = FALSE)
-	// - not yet exhausted (attempt_count < max)
-	// - not too old (created_at > cutoff)
+	// Find failed deliveries that are eligible for retry.
+	// Use created_at as proxy for last attempt time — the worker only processes
+	// one batch per minute, so backoff is computed from creation + cumulative delay.
 	rows, err := w.db.QueryContext(ctx, `
 		SELECT wd.id, wd.webhook_id, wd.event_type, wd.payload, wd.attempt_count, wd.created_at,
-		       wh.url, wh.secret, wh.is_active
+		       wh.url, wh.secret
 		FROM webhook_deliveries wd
 		JOIN webhooks wh ON wd.webhook_id = wh.id
 		WHERE wd.success = FALSE
@@ -513,29 +520,40 @@ func (w *WebhookRetryWorker) retryFailedDeliveries() {
 	var deliveries []failedDelivery
 	for rows.Next() {
 		var d failedDelivery
-		var isActive bool
-		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.AttemptCount, &d.CreatedAt, &d.URL, &d.Secret, &isActive); err != nil {
+		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.AttemptCount, &d.CreatedAt, &d.URL, &d.Secret); err != nil {
 			continue
 		}
-		// Check backoff: only retry if enough time has passed since creation
-		backoff := webhookRetryBackoff(d.AttemptCount)
-		if time.Since(d.CreatedAt) < backoff {
+		// Compute cumulative backoff from creation time to space out retries
+		var cumulative time.Duration
+		for i := 3; i < d.AttemptCount; i++ {
+			cumulative += webhookRetryBackoff(i)
+		}
+		cumulative += webhookRetryBackoff(d.AttemptCount)
+		if time.Since(d.CreatedAt) < cumulative {
 			continue
 		}
 		deliveries = append(deliveries, d)
 	}
 
 	for _, d := range deliveries {
+		// Respect shutdown
+		if ctx.Err() != nil {
+			return
+		}
+
 		signature := generateWebhookSignature([]byte(d.Payload), d.Secret)
 		respCode, respBody, err := w.server.sendWebhookRequest(d.URL, []byte(d.Payload), signature)
 
 		if err == nil && respCode >= 200 && respCode < 300 {
 			// Success — mark delivery as successful
-			w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET success = TRUE, response_code = ?, response_body = ?, attempt_count = ? WHERE id = ?`,
-				respCode, truncateString(respBody, 1000), d.AttemptCount+1, d.ID)
-			// Reset webhook failure count
-			w.db.ExecContext(ctx, `UPDATE webhooks SET failure_count = 0, last_success_at = ?, last_triggered_at = ? WHERE id = ?`,
-				time.Now(), time.Now(), d.WebhookID)
+			if _, dbErr := w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET success = TRUE, response_code = ?, response_body = ?, attempt_count = ? WHERE id = ?`,
+				respCode, truncateString(respBody, 1000), d.AttemptCount+1, d.ID); dbErr != nil {
+				w.server.logger.Error("Failed to update delivery success", "delivery_id", d.ID, "error", dbErr.Error())
+			}
+			if _, dbErr := w.db.ExecContext(ctx, `UPDATE webhooks SET failure_count = 0, last_success_at = ?, last_triggered_at = ? WHERE id = ?`,
+				time.Now(), time.Now(), d.WebhookID); dbErr != nil {
+				w.server.logger.Error("Failed to reset webhook failure count", "webhook_id", d.WebhookID, "error", dbErr.Error())
+			}
 			w.server.logger.Info("Webhook retry succeeded",
 				"delivery_id", d.ID, "webhook_id", d.WebhookID, "attempt", d.AttemptCount+1)
 		} else {
@@ -544,8 +562,13 @@ func (w *WebhookRetryWorker) retryFailedDeliveries() {
 			if err != nil {
 				errMsg = err.Error()
 			}
-			w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET attempt_count = ?, response_code = ?, response_body = ? WHERE id = ?`,
-				d.AttemptCount+1, respCode, truncateString(errMsg, 1000), d.ID)
+			if respBody != "" && errMsg == "" {
+				errMsg = respBody
+			}
+			if _, dbErr := w.db.ExecContext(ctx, `UPDATE webhook_deliveries SET attempt_count = ?, response_code = ?, response_body = ? WHERE id = ?`,
+				d.AttemptCount+1, respCode, truncateString(errMsg, 1000), d.ID); dbErr != nil {
+				w.server.logger.Error("Failed to update delivery attempt", "delivery_id", d.ID, "error", dbErr.Error())
+			}
 
 			if d.AttemptCount+1 >= webhookMaxRetryAttempts {
 				w.server.logger.Warn("Webhook delivery exhausted all retries",

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -498,7 +498,7 @@ func (w *WebhookRetryWorker) retryFailedDeliveries(ctx context.Context) {
 		  AND wh.is_active = TRUE
 		  AND wh.failure_count < ?
 		ORDER BY wd.created_at ASC
-		LIMIT 50
+		LIMIT 200
 	`, webhookMaxRetryAttempts, cutoff, webhookMaxFailures)
 	if err != nil {
 		w.server.logger.Error("Failed to query failed webhook deliveries", "error", err.Error())
@@ -519,6 +519,9 @@ func (w *WebhookRetryWorker) retryFailedDeliveries(ctx context.Context) {
 
 	var deliveries []failedDelivery
 	for rows.Next() {
+		if len(deliveries) >= 50 {
+			break
+		}
 		var d failedDelivery
 		if err := rows.Scan(&d.ID, &d.WebhookID, &d.EventType, &d.Payload, &d.AttemptCount, &d.CreatedAt, &d.URL, &d.Secret); err != nil {
 			continue

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -79,6 +79,11 @@ func New(cfg Config) (*Logger, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Enforce permissions on existing files too (OpenFile only sets mode on create)
+		if chmodErr := f.Chmod(0640); chmodErr != nil {
+			f.Close()
+			return nil, chmodErr
+		}
 		output = f
 	}
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -75,7 +75,7 @@ func New(cfg Config) (*Logger, error) {
 	case "stderr":
 		output = os.Stderr
 	default:
-		f, err := os.OpenFile(cfg.Output, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		f, err := os.OpenFile(cfg.Output, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0640)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/updater/deploy.go
+++ b/internal/updater/deploy.go
@@ -52,7 +52,7 @@ func (dm *DeployManager) Deploy(ctx context.Context, newBinaryPath string) error
 	}
 
 	// Make the binary executable
-	if err := os.Chmod(targetPath, 0755); err != nil {
+	if err := os.Chmod(targetPath, 0750); err != nil {
 		return fmt.Errorf("failed to chmod binary: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Add background webhook retry worker with extended exponential backoff (1m→5m→30m→2h→8h) for up to 8 total attempts over 24 hours, replacing the previous 3-attempt/14-second window
- Tighten file and directory permissions across the codebase: log files 0644→0640, deployed binaries 0755→0750, backup/restore directories 0755→0750

## Changes

### Webhook retry (#36)
- New `WebhookRetryWorker` in `internal/api/webhooks.go` — queries `webhook_deliveries` for failed entries, retries with backoff
- Worker starts/stops with the API server lifecycle
- Successful retries reset the webhook's `failure_count`
- Exhausted deliveries logged for visibility

### File permissions (#26)
- `internal/logging/logger.go` — log file 0644→0640
- `internal/updater/deploy.go` — binary chmod 0755→0750
- `cmd/mailserver/main.go` — backup/restore dirs 0755→0750
- `internal/admin/api_handlers_v2.go` — backup dirs 0755→0750
- `internal/admin/handlers.go` — restore dirs 0755→0750

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` all pass
- [ ] Verify webhook retry: disable endpoint, trigger event, re-enable within retry window
- [ ] Verify new log files created with 0640 permissions
- [ ] Verify backup directories created with 0750 permissions

Closes #36
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fenilsonani/email-server/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhooks now automatically retry failed deliveries with progressive backoff to improve delivery reliability.

* **Security Improvements**
  * Tightened file and directory permissions across backups, logging, and deployments to reduce exposure.

* **Reliability / Error Handling**
  * Backup restore and related flows now surface and abort on directory preparation failures, yielding clearer error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->