### PR TITLE
fix(updater): implement rollback restore flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download
@@ -249,7 +249,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.x'
 
       - name: Download dependencies
         run: go mod download
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.x'
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
@@ -186,7 +186,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.x'
 
       - name: Download dependencies
         run: go mod download
@@ -216,7 +216,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.x'
 
       - name: Download dependencies
         run: go mod download
@@ -249,7 +249,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.8'
+          go-version: '1.25.x'
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Download dependencies
         run: go mod download

--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ go test -v ./internal/auth/...
 go test -v ./internal/smtp/delivery/...
 ```
 
+## Current Limitations
+
+- Priority-based delivery queuing is not wired through the delivery engine yet.
+- Update rollback now restores the last saved backup, but it still depends on a valid pre-update backup path.
+- Some admin and user portal flows are still being polished for validation and error messaging.
+
 ## Security Notes
 
 - Put the admin panel behind a reverse proxy with restricted access

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -301,7 +301,7 @@ func (s *Server) Start(listen string) error {
 	mux.HandleFunc("/admin/api/v1/system/2fa/disable", s.withAPIAuth(s.handleAPI2FADisable))
 	// System: Updates
 	mux.HandleFunc("/admin/api/v1/system/check-update", s.withAPIAuth(s.handleAPICheckUpdate))
-	mux.HandleFunc("/admin/system/update/rollback/", s.HandleRollbackUpdate)
+	mux.HandleFunc("/admin/api/v1/system/update/rollback/", s.withAPIAuth(s.HandleRollbackUpdate))
 	// System: DKIM Auto-Rotate
 	mux.HandleFunc("/admin/api/v1/system/dkim-autorotate", s.withAPIAuth(s.handleAPIDKIMAutoRotate))
 	mux.HandleFunc("/admin/api/v1/system/dkim-autorotate/rotate-now", s.withAPIAuth(s.handleAPIDKIMAutoRotate))

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -38,20 +38,20 @@ var staticFS embed.FS
 
 // Server handles the admin web interface
 type Server struct {
-	config        *config.Config
-	db            *sql.DB
-	authenticator *auth.Authenticator
-	store         *maildir.Store
-	sieveStore    *sieve.Store
-	featuresStore *features.Store
-	listsStore    *lists.Store
-	orgStore      *org.Store
-	queue          *queue.RedisQueue
-	deliveryEngine *delivery.Engine
-	queuePath      string
-	logger         *logging.Logger
-	auditLogger   *audit.Logger
-	templates     map[string]*template.Template
+	config             *config.Config
+	db                 *sql.DB
+	authenticator      *auth.Authenticator
+	store              *maildir.Store
+	sieveStore         *sieve.Store
+	featuresStore      *features.Store
+	listsStore         *lists.Store
+	orgStore           *org.Store
+	queue              *queue.RedisQueue
+	deliveryEngine     *delivery.Engine
+	queuePath          string
+	logger             *logging.Logger
+	auditLogger        *audit.Logger
+	templates          map[string]*template.Template
 	httpServer         *http.Server
 	shutdownOnce       sync.Once
 	rateLimiter        *RateLimiter
@@ -179,13 +179,13 @@ func NewServer(cfg *config.Config, db *sql.DB, authenticator *auth.Authenticator
 	}
 
 	s := &Server{
-		config:        cfg,
-		db:            db,
-		authenticator: authenticator,
-		store:         store,
-		sieveStore:    sieveStore,
-		queue:         q,
-		logger:        logger,
+		config:             cfg,
+		db:                 db,
+		authenticator:      authenticator,
+		store:              store,
+		sieveStore:         sieveStore,
+		queue:              q,
+		logger:             logger,
 		auditLogger:        auditLog,
 		templates:          templates,
 		rateLimiter:        DefaultRateLimiter(),
@@ -301,6 +301,7 @@ func (s *Server) Start(listen string) error {
 	mux.HandleFunc("/admin/api/v1/system/2fa/disable", s.withAPIAuth(s.handleAPI2FADisable))
 	// System: Updates
 	mux.HandleFunc("/admin/api/v1/system/check-update", s.withAPIAuth(s.handleAPICheckUpdate))
+	mux.HandleFunc("/admin/system/update/rollback/", s.HandleRollbackUpdate)
 	// System: DKIM Auto-Rotate
 	mux.HandleFunc("/admin/api/v1/system/dkim-autorotate", s.withAPIAuth(s.handleAPIDKIMAutoRotate))
 	mux.HandleFunc("/admin/api/v1/system/dkim-autorotate/rotate-now", s.withAPIAuth(s.handleAPIDKIMAutoRotate))

--- a/internal/admin/update_handlers.go
+++ b/internal/admin/update_handlers.go
@@ -395,7 +395,8 @@ func (s *Server) HandleRollbackUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updateMgr := updater.NewUpdateManager(s.db, &s.config.Updater, s.logger, nil)
+	doc := doctor.New(s.config, s.queue)
+	updateMgr := updater.NewUpdateManager(s.db, &s.config.Updater, s.logger, doc)
 	if err := updateMgr.RollbackUpdate(ctx, updateID); err != nil {
 		s.auditLogger.Log(ctx, username, audit.EventConfigChange, "system_rollback", map[string]interface{}{
 			"update_id": updateID,

--- a/internal/admin/update_handlers.go
+++ b/internal/admin/update_handlers.go
@@ -380,6 +380,10 @@ func (s *Server) HandleRollbackUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 
 	ctx := r.Context()
 	username := s.getUsername(r)
@@ -391,15 +395,32 @@ func (s *Server) HandleRollbackUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Implement rollback logic
+	updateMgr := updater.NewUpdateManager(s.db, &s.config.Updater, s.logger, nil)
+	if err := updateMgr.RollbackUpdate(ctx, updateID); err != nil {
+		s.auditLogger.Log(ctx, username, audit.EventConfigChange, "system_rollback", map[string]interface{}{
+			"update_id": updateID,
+			"status":    "failed",
+			"error":     err.Error(),
+		}, getClientIP(r))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"message": fmt.Sprintf("Rollback failed: %v", err),
+		})
+		return
+	}
+
 	s.auditLogger.Log(ctx, username, audit.EventConfigChange, "system_rollback", map[string]interface{}{
 		"update_id": updateID,
+		"status":    "completed",
 	}, getClientIP(r))
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"success": false,
-		"message": "Rollback not yet implemented",
+		"success":   true,
+		"message":   "Rollback completed",
+		"update_id": updateID,
 	})
 }
 

--- a/internal/admin/update_handlers.go
+++ b/internal/admin/update_handlers.go
@@ -374,24 +374,24 @@ func (s *Server) HandleGetUpdateHistory(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(history)
 }
 
-// HandleRollbackUpdate rolls back to a previous version
+// HandleRollbackUpdate rolls back to a previous version.
+//
+// Authentication and admin-check are handled by the withAPIAuth middleware
+// wrapping this handler at the mux level (see server.go). Error responses
+// are JSON to match the rest of the /admin/api/v1 contract.
 func (s *Server) HandleRollbackUpdate(w http.ResponseWriter, r *http.Request) {
-	if !s.isAdmin(r) {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		s.jsonError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
 	ctx := r.Context()
 	username := s.getUsername(r)
 
-	updateIDStr := strings.TrimPrefix(r.URL.Path, "/admin/system/update/rollback/")
+	updateIDStr := strings.TrimPrefix(r.URL.Path, "/admin/api/v1/system/update/rollback/")
 	updateID, err := strconv.ParseInt(updateIDStr, 10, 64)
 	if err != nil {
-		http.Error(w, "Invalid update ID", http.StatusBadRequest)
+		s.jsonError(w, http.StatusBadRequest, "Invalid update ID")
 		return
 	}
 
@@ -403,12 +403,7 @@ func (s *Server) HandleRollbackUpdate(w http.ResponseWriter, r *http.Request) {
 			"status":    "failed",
 			"error":     err.Error(),
 		}, getClientIP(r))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"success": false,
-			"message": fmt.Sprintf("Rollback failed: %v", err),
-		})
+		s.jsonError(w, http.StatusInternalServerError, fmt.Sprintf("Rollback failed: %v", err))
 		return
 	}
 

--- a/internal/admin/update_handlers_test.go
+++ b/internal/admin/update_handlers_test.go
@@ -165,6 +165,8 @@ func TestUpdateHandlersGetClientIP_TrustedLocalProxyOnly(t *testing.T) {
 	})
 }
 
+const rollbackURLPrefix = "/admin/api/v1/system/update/rollback/"
+
 func newRollbackRequest(path, token string, method string) *http.Request {
 	req := httptest.NewRequest(method, path, nil)
 	if token != "" {
@@ -177,7 +179,7 @@ func TestHandleRollbackUpdate(t *testing.T) {
 	server, cleanup, updateID, token, binaryPath := setupRollbackHandlerTest(t)
 	defer cleanup()
 
-	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodPost)
+	req := newRollbackRequest(rollbackURLPrefix+strconv.FormatInt(updateID, 10), token, http.MethodPost)
 	w := httptest.NewRecorder()
 
 	server.HandleRollbackUpdate(w, req)
@@ -212,17 +214,36 @@ func TestHandleRollbackUpdate(t *testing.T) {
 	}
 }
 
+// decodeAPIResponse decodes the standard JSON error/success envelope used
+// by s.jsonError and confirms the response is valid JSON.
+func decodeAPIResponse(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var resp map[string]interface{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("failed to decode JSON response %q: %v", string(body), err)
+	}
+	return resp
+}
+
+// TestHandleRollbackUpdate_Unauthorized exercises the withAPIAuth middleware
+// that wraps the rollback handler at the mux level. The handler itself no
+// longer does an isAdmin check — that's the middleware's job — so this test
+// calls the wrapped handler to verify the full auth path returns a JSON 401.
 func TestHandleRollbackUpdate_Unauthorized(t *testing.T) {
 	server, cleanup, updateID, _, binaryPath := setupRollbackHandlerTest(t)
 	defer cleanup()
 
 	// No session cookie at all.
-	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), "", http.MethodPost)
+	req := newRollbackRequest(rollbackURLPrefix+strconv.FormatInt(updateID, 10), "", http.MethodPost)
 	w := httptest.NewRecorder()
-	server.HandleRollbackUpdate(w, req)
+	server.withAPIAuth(server.HandleRollbackUpdate)(w, req)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	resp := decodeAPIResponse(t, w.Body.Bytes())
+	if success, _ := resp["success"].(bool); success {
+		t.Fatalf("expected success=false in unauthorized response, got %#v", resp)
 	}
 	// Unauthorized request must not touch the binary.
 	data, err := os.ReadFile(binaryPath)
@@ -238,12 +259,16 @@ func TestHandleRollbackUpdate_MethodNotAllowed(t *testing.T) {
 	server, cleanup, updateID, token, _ := setupRollbackHandlerTest(t)
 	defer cleanup()
 
-	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodGet)
+	req := newRollbackRequest(rollbackURLPrefix+strconv.FormatInt(updateID, 10), token, http.MethodGet)
 	w := httptest.NewRecorder()
 	server.HandleRollbackUpdate(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+	resp := decodeAPIResponse(t, w.Body.Bytes())
+	if success, _ := resp["success"].(bool); success {
+		t.Fatalf("expected success=false in 405 response, got %#v", resp)
 	}
 }
 
@@ -251,12 +276,16 @@ func TestHandleRollbackUpdate_InvalidID(t *testing.T) {
 	server, cleanup, _, token, _ := setupRollbackHandlerTest(t)
 	defer cleanup()
 
-	req := newRollbackRequest("/admin/system/update/rollback/not-a-number", token, http.MethodPost)
+	req := newRollbackRequest(rollbackURLPrefix+"not-a-number", token, http.MethodPost)
 	w := httptest.NewRecorder()
 	server.HandleRollbackUpdate(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	resp := decodeAPIResponse(t, w.Body.Bytes())
+	if success, _ := resp["success"].(bool); success {
+		t.Fatalf("expected success=false in 400 response, got %#v", resp)
 	}
 }
 
@@ -270,12 +299,16 @@ func TestHandleRollbackUpdate_NotAvailable(t *testing.T) {
 		t.Fatalf("failed to clear rollback_available: %v", err)
 	}
 
-	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodPost)
+	req := newRollbackRequest(rollbackURLPrefix+strconv.FormatInt(updateID, 10), token, http.MethodPost)
 	w := httptest.NewRecorder()
 	server.HandleRollbackUpdate(w, req)
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	resp := decodeAPIResponse(t, w.Body.Bytes())
+	if success, _ := resp["success"].(bool); success {
+		t.Fatalf("expected success=false in 500 response, got %#v", resp)
 	}
 	// Binary must not be restored when the rollback is not available.
 	data, err := os.ReadFile(binaryPath)

--- a/internal/admin/update_handlers_test.go
+++ b/internal/admin/update_handlers_test.go
@@ -126,10 +126,11 @@ func setupRollbackHandlerTest(t *testing.T) (*Server, func(), int64, string, str
 	cfg := &config.Config{
 		Server: config.ServerConfig{Hostname: "mail.example.com"},
 		Updater: config.UpdaterConfig{
-			GitRepoURL:     "https://github.com/fenilsonani/email-server",
-			BuildPath:      buildDir,
-			BinaryPath:     binaryPath,
-			SystemdService: "mailserver.service",
+			GitRepoURL:         "https://github.com/fenilsonani/email-server",
+			BuildPath:          buildDir,
+			BinaryPath:         binaryPath,
+			SystemdService:     "mailserver.service",
+			SkipServiceRestart: true, // tests must not exec systemctl
 		},
 	}
 	server := &Server{

--- a/internal/admin/update_handlers_test.go
+++ b/internal/admin/update_handlers_test.go
@@ -165,13 +165,19 @@ func TestUpdateHandlersGetClientIP_TrustedLocalProxyOnly(t *testing.T) {
 	})
 }
 
+func newRollbackRequest(path, token string, method string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: "admin_session", Value: token})
+	}
+	return req
+}
+
 func TestHandleRollbackUpdate(t *testing.T) {
 	server, cleanup, updateID, token, binaryPath := setupRollbackHandlerTest(t)
 	defer cleanup()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/system/update/rollback/1", nil)
-	req.AddCookie(&http.Cookie{Name: "admin_session", Value: token})
-	req.URL.Path = "/admin/system/update/rollback/" + strconv.FormatInt(updateID, 10)
+	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodPost)
 	w := httptest.NewRecorder()
 
 	server.HandleRollbackUpdate(w, req)
@@ -203,5 +209,80 @@ func TestHandleRollbackUpdate(t *testing.T) {
 	}
 	if rollbackAvailable {
 		t.Fatalf("rollback_available = true, want false")
+	}
+}
+
+func TestHandleRollbackUpdate_Unauthorized(t *testing.T) {
+	server, cleanup, updateID, _, binaryPath := setupRollbackHandlerTest(t)
+	defer cleanup()
+
+	// No session cookie at all.
+	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), "", http.MethodPost)
+	w := httptest.NewRecorder()
+	server.HandleRollbackUpdate(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	// Unauthorized request must not touch the binary.
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("failed to read binary: %v", err)
+	}
+	if string(data) != "new binary" {
+		t.Fatalf("binary was restored on unauthorized request: %q", string(data))
+	}
+}
+
+func TestHandleRollbackUpdate_MethodNotAllowed(t *testing.T) {
+	server, cleanup, updateID, token, _ := setupRollbackHandlerTest(t)
+	defer cleanup()
+
+	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodGet)
+	w := httptest.NewRecorder()
+	server.HandleRollbackUpdate(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleRollbackUpdate_InvalidID(t *testing.T) {
+	server, cleanup, _, token, _ := setupRollbackHandlerTest(t)
+	defer cleanup()
+
+	req := newRollbackRequest("/admin/system/update/rollback/not-a-number", token, http.MethodPost)
+	w := httptest.NewRecorder()
+	server.HandleRollbackUpdate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleRollbackUpdate_NotAvailable(t *testing.T) {
+	server, cleanup, updateID, token, binaryPath := setupRollbackHandlerTest(t)
+	defer cleanup()
+
+	// Flip rollback_available off — an admin previously disabled it, or a
+	// prior rollback already consumed the claim.
+	if _, err := server.db.Exec(`UPDATE update_history SET rollback_available = 0 WHERE id = ?`, updateID); err != nil {
+		t.Fatalf("failed to clear rollback_available: %v", err)
+	}
+
+	req := newRollbackRequest("/admin/system/update/rollback/"+strconv.FormatInt(updateID, 10), token, http.MethodPost)
+	w := httptest.NewRecorder()
+	server.HandleRollbackUpdate(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	// Binary must not be restored when the rollback is not available.
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("failed to read binary: %v", err)
+	}
+	if string(data) != "new binary" {
+		t.Fatalf("binary was restored when rollback was unavailable: %q", string(data))
 	}
 }

--- a/internal/admin/update_handlers_test.go
+++ b/internal/admin/update_handlers_test.go
@@ -1,10 +1,147 @@
 package admin
 
 import (
+	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/fenilsonani/email-server/internal/audit"
+	"github.com/fenilsonani/email-server/internal/config"
+	"github.com/fenilsonani/email-server/internal/logging"
+	_ "github.com/mattn/go-sqlite3"
 )
+
+func setupRollbackHandlerTest(t *testing.T) (*Server, func(), int64, string, string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+
+	schema := `
+	CREATE TABLE users (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		username TEXT NOT NULL,
+		is_admin BOOLEAN DEFAULT FALSE
+	);
+	CREATE TABLE admin_sessions (
+		token TEXT PRIMARY KEY,
+		user_id INTEGER NOT NULL,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		expires_at DATETIME NOT NULL
+	);
+	CREATE TABLE update_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		update_type TEXT NOT NULL,
+		from_version TEXT,
+		to_version TEXT,
+		from_commit TEXT,
+		to_commit TEXT,
+		pr_number INTEGER,
+		branch_name TEXT,
+		status TEXT NOT NULL,
+		started_by TEXT NOT NULL,
+		started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		completed_at DATETIME,
+		duration_seconds INTEGER,
+		backup_path TEXT,
+		rollback_available BOOLEAN DEFAULT 1,
+		error_message TEXT,
+		metadata TEXT
+	);
+	CREATE TABLE rollback_snapshots (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		update_id INTEGER NOT NULL,
+		snapshot_type TEXT DEFAULT 'pre_update',
+		version TEXT NOT NULL,
+		commit_sha TEXT NOT NULL,
+		binary_path TEXT NOT NULL,
+		backup_path TEXT NOT NULL,
+		config_snapshot TEXT,
+		health_status TEXT,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		expires_at DATETIME
+	);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		db.Close()
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	logger := logging.Default()
+	auditLogger, err := audit.NewLogger(db)
+	if err != nil {
+		db.Close()
+		t.Fatalf("failed to create audit logger: %v", err)
+	}
+
+	buildDir := t.TempDir()
+	binaryPath := filepath.Join(buildDir, "mailserver")
+	backupDir := filepath.Join(buildDir, "backups", "pre-update-1")
+	if err := os.MkdirAll(backupDir, 0o750); err != nil {
+		db.Close()
+		t.Fatalf("failed to create backup dir: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("new binary"), 0o750); err != nil {
+		db.Close()
+		t.Fatalf("failed to write binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "mailserver-binary"), []byte("old binary"), 0o750); err != nil {
+		db.Close()
+		t.Fatalf("failed to write backup binary: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO users (id, username, is_admin) VALUES (1, 'admin', 1)`); err != nil {
+		db.Close()
+		t.Fatalf("failed to insert admin user: %v", err)
+	}
+	token := strings.Repeat("a", 32)
+	if _, err := db.Exec(`INSERT INTO admin_sessions (token, user_id, expires_at) VALUES (?, ?, ?)`, token, 1, time.Now().Add(time.Hour)); err != nil {
+		db.Close()
+		t.Fatalf("failed to insert session: %v", err)
+	}
+	result, err := db.Exec(`INSERT INTO update_history (update_type, from_version, to_version, from_commit, to_commit, status, started_by, backup_path, rollback_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`, "release", "v1.0.0", "v1.1.0", "oldcommit", "newcommit", "failed", "admin", backupDir)
+	if err != nil {
+		db.Close()
+		t.Fatalf("failed to insert update history: %v", err)
+	}
+	updateID, err := result.LastInsertId()
+	if err != nil {
+		db.Close()
+		t.Fatalf("failed to get update id: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO rollback_snapshots (update_id, snapshot_type, version, commit_sha, binary_path, backup_path) VALUES (?, 'pre_update', ?, ?, ?, ?)`, updateID, "v1.0.0", "oldcommit", binaryPath, backupDir); err != nil {
+		db.Close()
+		t.Fatalf("failed to insert rollback snapshot: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Hostname: "mail.example.com"},
+		Updater: config.UpdaterConfig{
+			GitRepoURL:     "https://github.com/fenilsonani/email-server",
+			BuildPath:      buildDir,
+			BinaryPath:     binaryPath,
+			SystemdService: "mailserver.service",
+		},
+	}
+	server := &Server{
+		db:          db,
+		logger:      logger,
+		auditLogger: auditLogger,
+		config:      cfg,
+	}
+
+	cleanup := func() { db.Close() }
+	return server, cleanup, updateID, token, binaryPath
+}
 
 func TestUpdateHandlersGetClientIP_TrustedLocalProxyOnly(t *testing.T) {
 	t.Run("uses forwarded header from trusted localhost proxy", func(t *testing.T) {
@@ -26,4 +163,45 @@ func TestUpdateHandlersGetClientIP_TrustedLocalProxyOnly(t *testing.T) {
 			t.Fatalf("getClientIP() = %q, want %q", got, "198.51.100.25")
 		}
 	})
+}
+
+func TestHandleRollbackUpdate(t *testing.T) {
+	server, cleanup, updateID, token, binaryPath := setupRollbackHandlerTest(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/system/update/rollback/1", nil)
+	req.AddCookie(&http.Cookie{Name: "admin_session", Value: token})
+	req.URL.Path = "/admin/system/update/rollback/" + strconv.FormatInt(updateID, 10)
+	w := httptest.NewRecorder()
+
+	server.HandleRollbackUpdate(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if success, _ := resp["success"].(bool); !success {
+		t.Fatalf("expected success response, got %#v", resp)
+	}
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("failed to read restored binary: %v", err)
+	}
+	if string(data) != "old binary" {
+		t.Fatalf("binary not restored, got %q", string(data))
+	}
+	var status string
+	var rollbackAvailable bool
+	if err := server.db.QueryRow(`SELECT status, rollback_available FROM update_history WHERE id = ?`, updateID).Scan(&status, &rollbackAvailable); err != nil {
+		t.Fatalf("failed to query update history: %v", err)
+	}
+	if status != "rolled_back" {
+		t.Fatalf("status = %q, want rolled_back", status)
+	}
+	if rollbackAvailable {
+		t.Fatalf("rollback_available = true, want false")
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,6 +227,7 @@ type UpdaterConfig struct {
 	AutoRollbackOnFailure  bool   `koanf:"auto_rollback_on_failure"`  // Automatically rollback on failure (default true)
 	BinaryPath             string `koanf:"binary_path"`               // Path to mailserver binary
 	SystemdService         string `koanf:"systemd_service"`           // Systemd service name (default "mailserver.service")
+	SkipServiceRestart     bool   `koanf:"skip_service_restart"`      // Skip systemctl restart on deploy/rollback; only for tests or external orchestrators (k8s, nomad) that manage process lifecycle. Operators who enable this are responsible for restarting the service themselves.
 }
 
 // DefaultConfig returns a configuration with sensible defaults

--- a/internal/updater/deploy.go
+++ b/internal/updater/deploy.go
@@ -57,7 +57,7 @@ func (dm *DeployManager) Deploy(ctx context.Context, newBinaryPath string) error
 	}
 
 	// Restart the service
-	if err := dm.restartService(ctx); err != nil {
+	if err := dm.RestartService(ctx); err != nil {
 		return fmt.Errorf("failed to restart service: %w", err)
 	}
 
@@ -105,27 +105,15 @@ func (dm *DeployManager) copyBinary(src, dst string) error {
 	return nil
 }
 
-// restartService restarts the systemd service
-func (dm *DeployManager) restartService(ctx context.Context) error {
+// RestartService restarts the systemd service. Exposed so rollback can
+// restart after restoring a prior binary.
+func (dm *DeployManager) RestartService(ctx context.Context) error {
 	dm.logger.Info("Restarting service", "service", dm.config.SystemdService)
 
 	cmd := exec.CommandContext(ctx, "systemctl", "restart", dm.config.SystemdService) // #nosec G204 -- service name validated and no shell is used
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("systemctl restart failed: %w, output: %s", err, string(output))
-	}
-
-	return nil
-}
-
-// stopService stops the systemd service
-func (dm *DeployManager) stopService(ctx context.Context) error {
-	dm.logger.Info("Stopping service", "service", dm.config.SystemdService)
-
-	cmd := exec.CommandContext(ctx, "systemctl", "stop", dm.config.SystemdService) // #nosec G204 -- service name validated and no shell is used
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("systemctl stop failed: %w, output: %s", err, string(output))
 	}
 
 	return nil
@@ -156,42 +144,6 @@ func (dm *DeployManager) GetServiceStatus(ctx context.Context) (string, error) {
 	}
 
 	return string(output[:len(output)-1]), nil
-}
-
-// Rollback restores the backed-up binary and restarts the service
-func (dm *DeployManager) Rollback(ctx context.Context) error {
-	dm.logger.Warn("Rolling back to previous binary")
-
-	targetPath := dm.config.BinaryPath
-	backupPath := targetPath + ".backup"
-
-	// Check if backup exists
-	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
-		return fmt.Errorf("backup binary not found: %s", backupPath)
-	}
-
-	// Stop the service
-	if err := dm.stopService(ctx); err != nil {
-		dm.logger.Warn("Failed to stop service", "error", err)
-	}
-
-	// Restore the backup
-	backupData, err := os.ReadFile(backupPath) // #nosec G304 -- backup path derived from validated binary path
-	if err != nil {
-		return fmt.Errorf("failed to read backup: %w", err)
-	}
-
-	if err := os.WriteFile(targetPath, backupData, 0750); err != nil {
-		return fmt.Errorf("failed to restore binary: %w", err)
-	}
-
-	// Restart the service
-	if err := dm.restartService(ctx); err != nil {
-		return fmt.Errorf("failed to restart service: %w", err)
-	}
-
-	dm.logger.Info("Rollback completed successfully")
-	return nil
 }
 
 // CopyBinaryForBackup creates a copy of the current binary at the specified location

--- a/internal/updater/integration_test.go
+++ b/internal/updater/integration_test.go
@@ -351,10 +351,11 @@ func TestIntegration_FailedUpdateWithRollback(t *testing.T) {
 	}
 
 	cfg := &config.UpdaterConfig{
-		GitRepoURL:     "https://github.com/fenilsonani/email-server",
-		BuildPath:      buildDir,
-		BinaryPath:     binaryPath,
-		SystemdService: "mailserver.service",
+		GitRepoURL:         "https://github.com/fenilsonani/email-server",
+		BuildPath:          buildDir,
+		BinaryPath:         binaryPath,
+		SystemdService:     "mailserver.service",
+		SkipServiceRestart: true, // tests must not exec systemctl
 	}
 	logger := logging.Default()
 

--- a/internal/updater/integration_test.go
+++ b/internal/updater/integration_test.go
@@ -3,6 +3,8 @@ package updater
 import (
 	"context"
 	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -335,9 +337,24 @@ func TestIntegration_FailedUpdateWithRollback(t *testing.T) {
 	db := setupIntegrationTestDB(t)
 	defer db.Close()
 
+	buildDir := t.TempDir()
+	binaryPath := filepath.Join(buildDir, "mailserver")
+	backupDir := filepath.Join(buildDir, "backups", "pre-update-1")
+	if err := os.MkdirAll(backupDir, 0o750); err != nil {
+		t.Fatalf("Failed to create backup dir: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("new binary"), 0o750); err != nil {
+		t.Fatalf("Failed to write binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "mailserver-binary"), []byte("old binary"), 0o750); err != nil {
+		t.Fatalf("Failed to write backup binary: %v", err)
+	}
+
 	cfg := &config.UpdaterConfig{
-		GitRepoURL: "https://github.com/fenilsonani/email-server",
-		BuildPath:  "/tmp/test-build",
+		GitRepoURL:     "https://github.com/fenilsonani/email-server",
+		BuildPath:      buildDir,
+		BinaryPath:     binaryPath,
+		SystemdService: "mailserver.service",
 	}
 	logger := logging.Default()
 
@@ -357,6 +374,12 @@ func TestIntegration_FailedUpdateWithRollback(t *testing.T) {
 	updateID, err := um.createUpdateHistory(ctx, opts, "v0.9.0", "old_commit")
 	if err != nil {
 		t.Fatalf("Failed to create update: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE update_history SET backup_path = ?, rollback_available = 1 WHERE id = ?`, backupDir, updateID); err != nil {
+		t.Fatalf("Failed to update rollback metadata: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO rollback_snapshots (update_id, snapshot_type, version, commit_sha, binary_path, backup_path) VALUES (?, 'pre_update', ?, ?, ?, ?)`, updateID, "v0.9.0", "old_commit", binaryPath, backupDir); err != nil {
+		t.Fatalf("Failed to insert rollback snapshot: %v", err)
 	}
 
 	t.Run("SimulateFailureAndRollback", func(t *testing.T) {
@@ -411,6 +434,25 @@ func TestIntegration_FailedUpdateWithRollback(t *testing.T) {
 		}
 		if errorMsg != "Build compilation failed" {
 			t.Errorf("Expected error message, got %q", errorMsg)
+		}
+
+		if err := um.RollbackUpdate(ctx, updateID); err != nil {
+			t.Fatalf("RollbackUpdate failed: %v", err)
+		}
+
+		data, err := os.ReadFile(binaryPath)
+		if err != nil {
+			t.Fatalf("Failed to read restored binary: %v", err)
+		}
+		if string(data) != "old binary" {
+			t.Fatalf("Expected restored binary contents, got %q", string(data))
+		}
+
+		if err := db.QueryRowContext(ctx, "SELECT status FROM update_history WHERE id = ?", updateID).Scan(&status); err != nil {
+			t.Fatalf("Failed to query rolled back status: %v", err)
+		}
+		if status != string(StatusRolledBack) {
+			t.Errorf("Expected status 'rolled_back', got %q", status)
 		}
 
 		// Verify only 3 of 8 steps completed before failure

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/fenilsonani/email-server/internal/config"
@@ -51,14 +52,14 @@ var UpdateSteps = []UpdateStep{
 
 // UpdateOptions specifies parameters for an update
 type UpdateOptions struct {
-	Mode           UpdateMode
-	TargetType     TargetType
-	Target         string // Version, PR#, branch name, or commit SHA
-	DryRun         bool
-	SkipBackup     bool
-	Force          bool
+	Mode            UpdateMode
+	TargetType      TargetType
+	Target          string // Version, PR#, branch name, or commit SHA
+	DryRun          bool
+	SkipBackup      bool
+	Force           bool
 	SkipHealthCheck bool
-	Username       string // Admin user performing the update
+	Username        string // Admin user performing the update
 }
 
 // UpdateResult contains the outcome of an update
@@ -142,6 +143,15 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			result.Errors = append(result.Errors, fmt.Sprintf("backup failed: %v", err))
 		} else {
 			result.BackupPath = backupPath
+			result.RollbackAvailable = true
+			if err := um.recordRollbackSnapshot(ctx, updateID, currentVersion, currentCommit, backupPath); err != nil {
+				um.logger.Warn("Failed to record rollback snapshot", "update_id", updateID, "error", err)
+				if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
+					um.logger.Warn("Failed to persist rollback availability", "update_id", updateID, "error", err)
+				}
+			} else if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
+				um.logger.Warn("Failed to persist rollback availability", "update_id", updateID, "error", err)
+			}
 			um.progressTracker.UpdateProgress(ctx, updateID, 2, "backup", "completed", "Backup created successfully")
 		}
 	}
@@ -164,7 +174,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 		um.progressTracker.UpdateProgress(ctx, updateID, 4, "build", "failed", fmt.Sprintf("Build failed: %v", err))
 		um.markUpdateFailed(ctx, updateID, fmt.Sprintf("build failed: %v", err))
 		if um.config.AutoRollbackOnFailure && result.BackupPath != "" {
-			um.rollbackUpdate(ctx, updateID)
+			if err := um.rollbackUpdate(ctx, updateID); err != nil {
+				um.logger.Error("Automatic rollback failed after build error", "update_id", updateID, "error", err)
+			}
 		}
 		return result, fmt.Errorf("build failed: %w", err)
 	}
@@ -177,7 +189,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			um.progressTracker.UpdateProgress(ctx, updateID, 5, "test", "failed", fmt.Sprintf("Tests failed: %v", err))
 			um.markUpdateFailed(ctx, updateID, fmt.Sprintf("test failed: %v", err))
 			if um.config.AutoRollbackOnFailure && result.BackupPath != "" {
-				um.rollbackUpdate(ctx, updateID)
+				if err := um.rollbackUpdate(ctx, updateID); err != nil {
+					um.logger.Error("Automatic rollback failed after test error", "update_id", updateID, "error", err)
+				}
 			}
 			return result, fmt.Errorf("test failed: %w", err)
 		}
@@ -192,7 +206,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 		um.progressTracker.UpdateProgress(ctx, updateID, 6, "deploy", "failed", fmt.Sprintf("Deploy failed: %v", err))
 		um.markUpdateFailed(ctx, updateID, fmt.Sprintf("deploy failed: %v", err))
 		if um.config.AutoRollbackOnFailure && result.BackupPath != "" {
-			um.rollbackUpdate(ctx, updateID)
+			if err := um.rollbackUpdate(ctx, updateID); err != nil {
+				um.logger.Error("Automatic rollback failed after deploy error", "update_id", updateID, "error", err)
+			}
 		}
 		return result, fmt.Errorf("deploy failed: %w", err)
 	}
@@ -206,7 +222,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			um.progressTracker.UpdateProgress(ctx, updateID, 7, "verify", "failed", "Health check returned no results")
 			um.markUpdateFailed(ctx, updateID, "health check failed: no results")
 			if um.config.AutoRollbackOnFailure && result.BackupPath != "" {
-				um.rollbackUpdate(ctx, updateID)
+				if err := um.rollbackUpdate(ctx, updateID); err != nil {
+					um.logger.Error("Automatic rollback failed after health-check error", "update_id", updateID, "error", err)
+				}
 			}
 			return result, fmt.Errorf("health check failed: no results")
 		}
@@ -217,7 +235,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			um.progressTracker.UpdateProgress(ctx, updateID, 7, "verify", "failed", fmt.Sprintf("Health check failed: %d checks failed", healthStatus.Failed))
 			um.markUpdateFailed(ctx, updateID, fmt.Sprintf("health check failed: %d checks failed", healthStatus.Failed))
 			if um.config.AutoRollbackOnFailure && result.BackupPath != "" {
-				um.rollbackUpdate(ctx, updateID)
+				if err := um.rollbackUpdate(ctx, updateID); err != nil {
+					um.logger.Error("Automatic rollback failed after health-check error", "update_id", updateID, "error", err)
+				}
 			}
 			return result, fmt.Errorf("health check failed: %d checks failed", healthStatus.Failed)
 		}
@@ -252,8 +272,8 @@ func (um *UpdateManager) getCurrentVersion(ctx context.Context) (string, string,
 
 func (um *UpdateManager) createUpdateHistory(ctx context.Context, opts UpdateOptions, fromVersion, fromCommit string) (int64, error) {
 	query := `
-	INSERT INTO update_history (update_type, from_version, from_commit, status, started_by, pr_number, branch_name)
-	VALUES (?, ?, ?, ?, ?, ?, ?)
+	INSERT INTO update_history (update_type, from_version, from_commit, status, started_by, pr_number, branch_name, backup_path, rollback_available)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	var prNumber *int
 	if opts.TargetType == TargetTypePR {
@@ -278,6 +298,8 @@ func (um *UpdateManager) createUpdateHistory(ctx context.Context, opts UpdateOpt
 			}
 			return nil
 		}(),
+		nil,
+		false,
 	)
 	if err != nil {
 		return 0, err
@@ -317,13 +339,83 @@ func (um *UpdateManager) markUpdateFailed(ctx context.Context, updateID int64, e
 }
 
 func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) error {
-	um.logger.Warn("Initiating automatic rollback", "update_id", updateID)
-	// TODO: Implement rollback logic
+	backupPath, err := um.getRollbackBackupPath(ctx, updateID)
+	if err != nil {
+		return err
+	}
+	if backupPath == "" {
+		return fmt.Errorf("rollback backup not available for update %d", updateID)
+	}
+
+	um.logger.Warn("Initiating rollback", "update_id", updateID, "backup_path", backupPath)
+	if err := um.backupManager.RestoreFromBackup(ctx, backupPath); err != nil {
+		return err
+	}
+
 	query := `
 	UPDATE update_history
-	SET status = ?
+	SET status = ?, completed_at = ?, rollback_available = 0
 	WHERE id = ?
 	`
-	_, err := um.db.ExecContext(ctx, query, StatusRolledBack, updateID)
+	_, err = um.db.ExecContext(ctx, query, StatusRolledBack, time.Now(), updateID)
 	return err
+}
+
+// RollbackUpdate restores a previously backed-up version for the given update.
+func (um *UpdateManager) RollbackUpdate(ctx context.Context, updateID int64) error {
+	return um.rollbackUpdate(ctx, updateID)
+}
+
+func (um *UpdateManager) markRollbackAvailable(ctx context.Context, updateID int64, backupPath string) error {
+	query := `
+	UPDATE update_history
+	SET backup_path = ?, rollback_available = 1
+	WHERE id = ?
+	`
+	_, err := um.db.ExecContext(ctx, query, backupPath, updateID)
+	return err
+}
+
+func (um *UpdateManager) recordRollbackSnapshot(ctx context.Context, updateID int64, version, commitSHA, backupPath string) error {
+	query := `
+	INSERT INTO rollback_snapshots (update_id, snapshot_type, version, commit_sha, binary_path, backup_path, config_snapshot, health_status)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	_, err := um.db.ExecContext(ctx, query,
+		updateID,
+		"pre_update",
+		version,
+		commitSHA,
+		um.config.BinaryPath,
+		backupPath,
+		nil,
+		nil,
+	)
+	return err
+}
+
+func (um *UpdateManager) getRollbackBackupPath(ctx context.Context, updateID int64) (string, error) {
+	var backupPath sql.NullString
+	err := um.db.QueryRowContext(ctx, `
+		SELECT backup_path
+		FROM rollback_snapshots
+		WHERE update_id = ?
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1
+	`, updateID).Scan(&backupPath)
+	if err == nil && backupPath.Valid && strings.TrimSpace(backupPath.String) != "" {
+		return backupPath.String, nil
+	}
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	var historyBackup sql.NullString
+	if err := um.db.QueryRowContext(ctx, `SELECT backup_path FROM update_history WHERE id = ?`, updateID).Scan(&historyBackup); err != nil {
+		return "", err
+	}
+	if historyBackup.Valid {
+		return historyBackup.String, nil
+	}
+	return "", nil
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -344,24 +344,33 @@ func (um *UpdateManager) markUpdateFailed(ctx context.Context, updateID int64, e
 	return err
 }
 
-// rollbackUpdate restores the binary recorded in the pre-update snapshot for
-// updateID and restarts the service. It is safe against concurrent callers:
-// the first caller atomically claims the rollback by flipping
-// rollback_available from 1 to 0, and any concurrent caller observes zero
-// rows affected and returns an error. If any step after the claim fails,
-// the claim is released so an operator can retry.
+// rollbackUpdate restores the binary recorded in the pre-update snapshot
+// for updateID and restarts the service. Several things are load-bearing
+// about the ordering below:
 //
-// Once the claim is taken, the rollback runs on a detached context with a
-// generous timeout so that an admin closing their browser mid-rollback
-// cannot kill the restore, restart, or finalise steps and leave the system
-// in a half-rolled-back state.
+//  1. Atomic claim. Only updates in a terminal state (failed/completed)
+//     with a live backup are eligible — this prevents rolling back an
+//     update still in progress, and prevents two admins from racing on
+//     the same update.
+//  2. Detached context. Once the claim is taken, the rollback must run
+//     to completion regardless of whether the admin's browser stays open.
+//  3. DB state is written *before* the service restart. The admin server
+//     runs inside the mail server process, so a successful
+//     `systemctl restart mailserver.service` sends SIGTERM to this very
+//     process — any code after the restart call is not guaranteed to run.
+//     If we wrote "rolled_back" only after the restart, the self-restart
+//     case would leave update_history stuck at `failed`,
+//     rollback_available=0, and no way for the admin to see or retry.
+//  4. Compensation. If RestartService actually *returns* with an error,
+//     the restart did not happen (systemctl missing, unit file broken,
+//     permissions, etc.) — the service is still running the failed
+//     build. In that case we revert update_history back to its prior
+//     status/completed_at (captured before step 3), stamp the restart
+//     error into error_message for operator visibility, and let the
+//     defer release the claim so a retry is possible.
 func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) error {
-	// Atomically claim the rollback. Only updates in a terminal state
-	// (failed/completed) with a live backup are eligible — this prevents
-	// rolling back an update that's still in progress, and prevents two
-	// admins from rolling back the same update concurrently. The claim
-	// itself honours the caller's context: cancellation before we've
-	// committed to anything is fine.
+	// Step 1: Atomic claim on the caller's ctx. Cancellation here means
+	// nothing has changed yet, so the caller can safely retry.
 	claim, err := um.db.ExecContext(ctx, `
 		UPDATE update_history
 		SET rollback_available = 0
@@ -378,30 +387,32 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 		return fmt.Errorf("rollback not available for update %d", updateID)
 	}
 
-	// Detach from the caller's context for every subsequent step. Once we
-	// have the claim, the rollback must run to completion (or fail cleanly
-	// and release the claim) regardless of whether the admin stays connected.
+	// Step 2: Detach from the caller's context for everything below.
 	rollbackCtx, cancelRollback := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancelRollback()
 
-	// Release the claim on any failure below so the operator can retry. Use
-	// a second detached context so it survives even if rollbackCtx has been
-	// cancelled/timed-out by the time we reach the defer.
+	// Release the claim on any failure that reaches the defer (success
+	// will be set to true only when we've either finalised the rollback
+	// or handed control to a restart that will kill us). Uses its own
+	// detached context so it survives rollbackCtx expiring.
 	success := false
 	defer func() {
 		if success {
 			return
 		}
-		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if _, relErr := um.db.ExecContext(releaseCtx, `
-			UPDATE update_history
-			SET rollback_available = 1
-			WHERE id = ?
-		`, updateID); relErr != nil {
-			um.logger.Error("Failed to release rollback claim after error", "update_id", updateID, "error", relErr)
-		}
+		um.releaseRollbackClaim(updateID)
 	}()
+
+	// Capture the pre-rollback state so we can compensate if the restart
+	// step fails without SIGTERM-ing us (i.e. systemctl exec returned an
+	// error before it could signal this process).
+	var prevStatus string
+	var prevCompletedAt sql.NullTime
+	if err := um.db.QueryRowContext(rollbackCtx,
+		`SELECT status, completed_at FROM update_history WHERE id = ?`, updateID,
+	).Scan(&prevStatus, &prevCompletedAt); err != nil {
+		return fmt.Errorf("failed to read pre-rollback state: %w", err)
+	}
 
 	backupPath, err := um.getRollbackBackupPath(rollbackCtx, updateID)
 	if err != nil {
@@ -416,31 +427,83 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 		return fmt.Errorf("restore failed: %w", err)
 	}
 
-	// Restart the service so the restored binary actually takes effect.
-	// A failed restart means the running process is still on the failed
-	// build even though the binary on disk is correct, so we must NOT
-	// mark the update as rolled back in that case — the caller needs to
-	// know the rollback is only half-done and investigate.
-	//
-	// SkipServiceRestart is for tests and for production environments
-	// where service lifecycle is managed externally (k8s, nomad, etc.);
-	// in those cases the operator is responsible for the restart.
-	if um.deployManager != nil && !um.config.SkipServiceRestart {
-		if err := um.deployManager.RestartService(rollbackCtx); err != nil {
-			return fmt.Errorf("service restart after rollback failed: %w", err)
-		}
-	}
-
+	// Step 3: Mark the DB as rolled_back BEFORE calling RestartService.
+	// See the function doc comment: the admin server is embedded in the
+	// mail process, so a successful systemctl restart will SIGTERM us
+	// mid-function. Writing the status first makes the DB consistent
+	// with reality in that case.
 	if _, err := um.db.ExecContext(rollbackCtx, `
 		UPDATE update_history
-		SET status = ?, completed_at = ?
+		SET status = ?, completed_at = ?, error_message = NULL
 		WHERE id = ?
 	`, StatusRolledBack, time.Now(), updateID); err != nil {
 		return fmt.Errorf("failed to mark update rolled back: %w", err)
 	}
-
+	// From here on, a successful return (or death from SIGTERM during
+	// the restart) means the rollback is committed and the claim must
+	// NOT be released by the defer.
 	success = true
-	return nil
+
+	// Step 4: Restart the service. In the self-restart case this call
+	// never returns — we get SIGTERM'd while systemctl is stopping the
+	// unit, and the new process comes up with the restored binary. If
+	// this call DOES return with an error we know the restart didn't
+	// actually happen and we must compensate.
+	//
+	// SkipServiceRestart covers tests and production environments where
+	// service lifecycle is managed externally (k8s, nomad, etc.); in
+	// those cases the operator owns the restart and the DB row we just
+	// wrote is the correct final state.
+	if um.deployManager == nil || um.config.SkipServiceRestart {
+		return nil
+	}
+
+	// Give the restart its own fresh context so a nearly-expired
+	// rollbackCtx (e.g. after a slow restore) cannot doom it.
+	restartCtx, cancelRestart := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancelRestart()
+
+	restartErr := um.deployManager.RestartService(restartCtx)
+	if restartErr == nil {
+		// Either we got here because SkipServiceRestart is off but the
+		// process somehow survived (unusual, e.g. running outside systemd
+		// during development) or because the restart returned before
+		// SIGTERM propagated. Either way the rollback is done.
+		return nil
+	}
+
+	// Step 5: Compensate. The restart exec failed, so we are still the
+	// old binary running the failed build despite what the DB now says.
+	// Revert status/completed_at and stamp the restart error into
+	// error_message so the admin UI surfaces it. Release the claim via
+	// the defer by clearing success.
+	success = false
+	revertCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, rerr := um.db.ExecContext(revertCtx, `
+		UPDATE update_history
+		SET status = ?, completed_at = ?, error_message = ?
+		WHERE id = ?
+	`, prevStatus, prevCompletedAt, fmt.Sprintf("rollback restore succeeded but service restart failed: %v", restartErr), updateID); rerr != nil {
+		um.logger.Error("rollback half-committed: restart failed and compensation UPDATE also failed — manual intervention required",
+			"update_id", updateID, "restart_error", restartErr, "compensation_error", rerr)
+	}
+	return fmt.Errorf("service restart after rollback failed: %w", restartErr)
+}
+
+// releaseRollbackClaim resets rollback_available back to 1 so the
+// operator can retry. Uses a detached context so it works even when the
+// caller's or rollback's context has already been cancelled.
+func (um *UpdateManager) releaseRollbackClaim(updateID int64) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := um.db.ExecContext(ctx, `
+		UPDATE update_history
+		SET rollback_available = 1
+		WHERE id = ?
+	`, updateID); err != nil {
+		um.logger.Error("Failed to release rollback claim", "update_id", updateID, "error", err)
+	}
 }
 
 // RollbackUpdate restores a previously backed-up version for the given update.

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -472,7 +472,7 @@ func (um *UpdateManager) getRollbackBackupPath(ctx context.Context, updateID int
 	if err := um.db.QueryRowContext(ctx, `SELECT backup_path FROM update_history WHERE id = ?`, updateID).Scan(&historyBackup); err != nil {
 		return "", err
 	}
-	if historyBackup.Valid {
+	if historyBackup.Valid && strings.TrimSpace(historyBackup.String) != "" {
 		return historyBackup.String, nil
 	}
 	return "", nil

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -143,12 +143,18 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			result.Errors = append(result.Errors, fmt.Sprintf("backup failed: %v", err))
 		} else {
 			result.BackupPath = backupPath
-			result.RollbackAvailable = true
 			if err := um.recordRollbackSnapshot(ctx, updateID, currentVersion, currentCommit, backupPath); err != nil {
 				um.logger.Warn("Failed to record rollback snapshot", "update_id", updateID, "error", err)
 			}
+			// Only advertise the rollback as available once the DB row has
+			// been updated to reflect it. If this persistence fails we can
+			// still continue the update — but the caller must not be told
+			// rollback is available, because rollbackUpdate() will refuse to
+			// restore an update whose rollback_available column is not 1.
 			if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
 				um.logger.Warn("Failed to persist rollback availability", "update_id", updateID, "error", err)
+			} else {
+				result.RollbackAvailable = true
 			}
 			um.progressTracker.UpdateProgress(ctx, updateID, 2, "backup", "completed", "Backup created successfully")
 		}
@@ -253,7 +259,9 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 	result.Success = true
 	result.Duration = duration
 	result.StepsCompleted = 8
-	result.RollbackAvailable = result.BackupPath != ""
+	// result.RollbackAvailable is already set (or left false) during the
+	// backup step based on whether markRollbackAvailable actually persisted
+	// the state. Do not override it here.
 
 	return result, nil
 }
@@ -340,13 +348,20 @@ func (um *UpdateManager) markUpdateFailed(ctx context.Context, updateID int64, e
 // updateID and restarts the service. It is safe against concurrent callers:
 // the first caller atomically claims the rollback by flipping
 // rollback_available from 1 to 0, and any concurrent caller observes zero
-// rows affected and returns an error. If the restore fails mid-flight, the
-// claim is released so an operator can retry.
+// rows affected and returns an error. If any step after the claim fails,
+// the claim is released so an operator can retry.
+//
+// Once the claim is taken, the rollback runs on a detached context with a
+// generous timeout so that an admin closing their browser mid-rollback
+// cannot kill the restore, restart, or finalise steps and leave the system
+// in a half-rolled-back state.
 func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) error {
 	// Atomically claim the rollback. Only updates in a terminal state
 	// (failed/completed) with a live backup are eligible — this prevents
 	// rolling back an update that's still in progress, and prevents two
-	// admins from rolling back the same update concurrently.
+	// admins from rolling back the same update concurrently. The claim
+	// itself honours the caller's context: cancellation before we've
+	// committed to anything is fine.
 	claim, err := um.db.ExecContext(ctx, `
 		UPDATE update_history
 		SET rollback_available = 0
@@ -363,10 +378,15 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 		return fmt.Errorf("rollback not available for update %d", updateID)
 	}
 
-	// Release the claim on any failure below so the operator can retry.
-	// Use a detached context with a short timeout so that client cancellation
-	// (e.g. the admin closing the browser mid-rollback) cannot also kill the
-	// compensating UPDATE and strand the row at rollback_available = 0.
+	// Detach from the caller's context for every subsequent step. Once we
+	// have the claim, the rollback must run to completion (or fail cleanly
+	// and release the claim) regardless of whether the admin stays connected.
+	rollbackCtx, cancelRollback := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancelRollback()
+
+	// Release the claim on any failure below so the operator can retry. Use
+	// a second detached context so it survives even if rollbackCtx has been
+	// cancelled/timed-out by the time we reach the defer.
 	success := false
 	defer func() {
 		if success {
@@ -383,7 +403,7 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 		}
 	}()
 
-	backupPath, err := um.getRollbackBackupPath(ctx, updateID)
+	backupPath, err := um.getRollbackBackupPath(rollbackCtx, updateID)
 	if err != nil {
 		return err
 	}
@@ -392,22 +412,26 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 	}
 
 	um.logger.Warn("Initiating rollback", "update_id", updateID, "backup_path", backupPath)
-	if err := um.backupManager.RestoreFromBackup(ctx, backupPath); err != nil {
+	if err := um.backupManager.RestoreFromBackup(rollbackCtx, backupPath); err != nil {
 		return fmt.Errorf("restore failed: %w", err)
 	}
 
 	// Restart the service so the restored binary actually takes effect.
-	// Best-effort: if systemctl is unavailable or the unit fails to come back
-	// up, the binary is already restored on disk, so log and carry on — the
-	// operator can finish the restart manually.
-	if um.deployManager != nil {
-		if err := um.deployManager.RestartService(ctx); err != nil {
-			um.logger.Warn("Service restart after rollback failed; binary is restored but manual restart may be required",
-				"update_id", updateID, "error", err)
+	// A failed restart means the running process is still on the failed
+	// build even though the binary on disk is correct, so we must NOT
+	// mark the update as rolled back in that case — the caller needs to
+	// know the rollback is only half-done and investigate.
+	//
+	// SkipServiceRestart is for tests and for production environments
+	// where service lifecycle is managed externally (k8s, nomad, etc.);
+	// in those cases the operator is responsible for the restart.
+	if um.deployManager != nil && !um.config.SkipServiceRestart {
+		if err := um.deployManager.RestartService(rollbackCtx); err != nil {
+			return fmt.Errorf("service restart after rollback failed: %w", err)
 		}
 	}
 
-	if _, err := um.db.ExecContext(ctx, `
+	if _, err := um.db.ExecContext(rollbackCtx, `
 		UPDATE update_history
 		SET status = ?, completed_at = ?
 		WHERE id = ?

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -146,10 +146,8 @@ func (um *UpdateManager) StartUpdate(ctx context.Context, opts UpdateOptions) (*
 			result.RollbackAvailable = true
 			if err := um.recordRollbackSnapshot(ctx, updateID, currentVersion, currentCommit, backupPath); err != nil {
 				um.logger.Warn("Failed to record rollback snapshot", "update_id", updateID, "error", err)
-				if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
-					um.logger.Warn("Failed to persist rollback availability", "update_id", updateID, "error", err)
-				}
-			} else if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
+			}
+			if err := um.markRollbackAvailable(ctx, updateID, backupPath); err != nil {
 				um.logger.Warn("Failed to persist rollback availability", "update_id", updateID, "error", err)
 			}
 			um.progressTracker.UpdateProgress(ctx, updateID, 2, "backup", "completed", "Backup created successfully")
@@ -338,7 +336,53 @@ func (um *UpdateManager) markUpdateFailed(ctx context.Context, updateID int64, e
 	return err
 }
 
+// rollbackUpdate restores the binary recorded in the pre-update snapshot for
+// updateID and restarts the service. It is safe against concurrent callers:
+// the first caller atomically claims the rollback by flipping
+// rollback_available from 1 to 0, and any concurrent caller observes zero
+// rows affected and returns an error. If the restore fails mid-flight, the
+// claim is released so an operator can retry.
 func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) error {
+	// Atomically claim the rollback. Only updates in a terminal state
+	// (failed/completed) with a live backup are eligible — this prevents
+	// rolling back an update that's still in progress, and prevents two
+	// admins from rolling back the same update concurrently.
+	claim, err := um.db.ExecContext(ctx, `
+		UPDATE update_history
+		SET rollback_available = 0
+		WHERE id = ? AND rollback_available = 1 AND status IN (?, ?)
+	`, updateID, StatusFailed, StatusCompleted)
+	if err != nil {
+		return fmt.Errorf("failed to claim rollback: %w", err)
+	}
+	claimed, err := claim.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rollback claim: %w", err)
+	}
+	if claimed == 0 {
+		return fmt.Errorf("rollback not available for update %d", updateID)
+	}
+
+	// Release the claim on any failure below so the operator can retry.
+	// Use a detached context with a short timeout so that client cancellation
+	// (e.g. the admin closing the browser mid-rollback) cannot also kill the
+	// compensating UPDATE and strand the row at rollback_available = 0.
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, relErr := um.db.ExecContext(releaseCtx, `
+			UPDATE update_history
+			SET rollback_available = 1
+			WHERE id = ?
+		`, updateID); relErr != nil {
+			um.logger.Error("Failed to release rollback claim after error", "update_id", updateID, "error", relErr)
+		}
+	}()
+
 	backupPath, err := um.getRollbackBackupPath(ctx, updateID)
 	if err != nil {
 		return err
@@ -349,16 +393,30 @@ func (um *UpdateManager) rollbackUpdate(ctx context.Context, updateID int64) err
 
 	um.logger.Warn("Initiating rollback", "update_id", updateID, "backup_path", backupPath)
 	if err := um.backupManager.RestoreFromBackup(ctx, backupPath); err != nil {
-		return err
+		return fmt.Errorf("restore failed: %w", err)
 	}
 
-	query := `
-	UPDATE update_history
-	SET status = ?, completed_at = ?, rollback_available = 0
-	WHERE id = ?
-	`
-	_, err = um.db.ExecContext(ctx, query, StatusRolledBack, time.Now(), updateID)
-	return err
+	// Restart the service so the restored binary actually takes effect.
+	// Best-effort: if systemctl is unavailable or the unit fails to come back
+	// up, the binary is already restored on disk, so log and carry on — the
+	// operator can finish the restart manually.
+	if um.deployManager != nil {
+		if err := um.deployManager.RestartService(ctx); err != nil {
+			um.logger.Warn("Service restart after rollback failed; binary is restored but manual restart may be required",
+				"update_id", updateID, "error", err)
+		}
+	}
+
+	if _, err := um.db.ExecContext(ctx, `
+		UPDATE update_history
+		SET status = ?, completed_at = ?
+		WHERE id = ?
+	`, StatusRolledBack, time.Now(), updateID); err != nil {
+		return fmt.Errorf("failed to mark update rolled back: %w", err)
+	}
+
+	success = true
+	return nil
 }
 
 // RollbackUpdate restores a previously backed-up version for the given update.

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -3,6 +3,8 @@ package updater
 import (
 	"context"
 	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -163,13 +165,13 @@ func TestNewUpdateManager(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.UpdaterConfig{
-		Mode:              "normal",
-		AutoCheckEnabled:  true,
-		AutoCheckInterval: 3600,
-		GitRepoURL:        "https://github.com/test/repo",
-		BuildPath:         "/tmp/test-build",
+		Mode:               "normal",
+		AutoCheckEnabled:   true,
+		AutoCheckInterval:  3600,
+		GitRepoURL:         "https://github.com/test/repo",
+		BuildPath:          "/tmp/test-build",
 		BackupBeforeUpdate: true,
-		MaxBackups:        5,
+		MaxBackups:         5,
 	}
 
 	logger := logging.Default()
@@ -308,5 +310,114 @@ func TestMarkUpdateFailed(t *testing.T) {
 	}
 	if errorMsg != "Build failed: missing dependency" {
 		t.Errorf("Expected error message, got %q", errorMsg)
+	}
+}
+
+func TestRollbackUpdateRestoresBackup(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	buildDir := t.TempDir()
+	binaryPath := filepath.Join(buildDir, "mailserver")
+	backupDir := filepath.Join(buildDir, "backups", "pre-update-1")
+	if err := os.MkdirAll(backupDir, 0o750); err != nil {
+		t.Fatalf("failed to create backup dir: %v", err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("new binary"), 0o750); err != nil {
+		t.Fatalf("failed to write binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "mailserver-binary"), []byte("old binary"), 0o750); err != nil {
+		t.Fatalf("failed to write backup binary: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO update_history (update_type, from_version, to_version, from_commit, to_commit, status, started_by, backup_path, rollback_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`, "release", "v1.0.0", "v1.1.0", "oldcommit", "newcommit", string(StatusFailed), "admin", backupDir); err != nil {
+		t.Fatalf("failed to insert update history: %v", err)
+	}
+	var updateID int64
+	if err := db.QueryRow(`SELECT id FROM update_history LIMIT 1`).Scan(&updateID); err != nil {
+		t.Fatalf("failed to get update id: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO rollback_snapshots (update_id, snapshot_type, version, commit_sha, binary_path, backup_path) VALUES (?, 'pre_update', ?, ?, ?, ?)`, updateID, "v1.0.0", "oldcommit", binaryPath, backupDir); err != nil {
+		t.Fatalf("failed to insert rollback snapshot: %v", err)
+	}
+
+	cfg := &config.UpdaterConfig{
+		GitRepoURL:     "https://github.com/fenilsonani/email-server",
+		BuildPath:      buildDir,
+		BinaryPath:     binaryPath,
+		SystemdService: "mailserver.service",
+	}
+	um := NewUpdateManager(db, cfg, logging.Default(), nil)
+
+	if err := um.RollbackUpdate(context.Background(), updateID); err != nil {
+		t.Fatalf("RollbackUpdate() error = %v", err)
+	}
+
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("failed to read restored binary: %v", err)
+	}
+	if string(data) != "old binary" {
+		t.Fatalf("restored binary = %q, want %q", string(data), "old binary")
+	}
+
+	var status string
+	var rollbackAvailable bool
+	if err := db.QueryRow(`SELECT status, rollback_available FROM update_history WHERE id = ?`, updateID).Scan(&status, &rollbackAvailable); err != nil {
+		t.Fatalf("failed to query update history: %v", err)
+	}
+	if status != string(StatusRolledBack) {
+		t.Fatalf("status = %q, want %q", status, StatusRolledBack)
+	}
+	if rollbackAvailable {
+		t.Fatal("rollback_available = true, want false")
+	}
+}
+
+func TestRecordRollbackSnapshotPersistsMetadata(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	buildDir := t.TempDir()
+	binaryPath := filepath.Join(buildDir, "mailserver")
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0o750); err != nil {
+		t.Fatalf("failed to write binary: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO update_history (update_type, from_version, to_version, from_commit, to_commit, status, started_by, rollback_available) VALUES (?, ?, ?, ?, ?, ?, ?, 0)`, "release", "v1.0.0", "v1.1.0", "oldcommit", "newcommit", string(StatusPending), "admin"); err != nil {
+		t.Fatalf("failed to insert update history: %v", err)
+	}
+	var updateID int64
+	if err := db.QueryRow(`SELECT id FROM update_history LIMIT 1`).Scan(&updateID); err != nil {
+		t.Fatalf("failed to get update id: %v", err)
+	}
+
+	cfg := &config.UpdaterConfig{BuildPath: buildDir, BinaryPath: binaryPath}
+	um := NewUpdateManager(db, cfg, logging.Default(), nil)
+	if err := um.recordRollbackSnapshot(context.Background(), updateID, "v1.0.0", "oldcommit", filepath.Join(buildDir, "backups", "pre-update-1")); err != nil {
+		t.Fatalf("recordRollbackSnapshot() error = %v", err)
+	}
+	if err := um.markRollbackAvailable(context.Background(), updateID, filepath.Join(buildDir, "backups", "pre-update-1")); err != nil {
+		t.Fatalf("markRollbackAvailable() error = %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM rollback_snapshots WHERE update_id = ?`, updateID).Scan(&count); err != nil {
+		t.Fatalf("failed to query rollback snapshots: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("rollback snapshot count = %d, want 1", count)
+	}
+
+	var backupPath string
+	var rollbackAvailable bool
+	if err := db.QueryRow(`SELECT backup_path, rollback_available FROM update_history WHERE id = ?`, updateID).Scan(&backupPath, &rollbackAvailable); err != nil {
+		t.Fatalf("failed to query update history: %v", err)
+	}
+	if backupPath == "" {
+		t.Fatal("expected backup path to be persisted")
+	}
+	if !rollbackAvailable {
+		t.Fatal("rollback_available = false, want true")
 	}
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -360,10 +360,11 @@ func newRollbackFixture(t *testing.T, status UpdateStatus, rollbackAvailable boo
 	}
 
 	cfg := &config.UpdaterConfig{
-		GitRepoURL:     "https://github.com/fenilsonani/email-server",
-		BuildPath:      buildDir,
-		BinaryPath:     binaryPath,
-		SystemdService: "mailserver.service",
+		GitRepoURL:         "https://github.com/fenilsonani/email-server",
+		BuildPath:          buildDir,
+		BinaryPath:         binaryPath,
+		SystemdService:     "mailserver.service",
+		SkipServiceRestart: true, // tests must not exec systemctl
 	}
 	return &rollbackFixture{
 		db:         db,
@@ -457,6 +458,31 @@ func TestRollbackUpdateRefusesInProgressUpdate(t *testing.T) {
 	}
 	if got := f.status(t); got != string(StatusInProgress) {
 		t.Fatalf("status = %q, want %q", got, StatusInProgress)
+	}
+}
+
+// A failed service restart must fail the rollback rather than silently
+// mark the update as rolled_back. Otherwise the DB would claim the rollback
+// succeeded while the running process is still on the failed build. The
+// claim must also be released so the operator can retry after fixing
+// whatever broke systemctl.
+func TestRollbackUpdateFailsOnRestartFailure(t *testing.T) {
+	f := newRollbackFixture(t, StatusFailed, true)
+	// Re-enable the systemctl restart path. On macOS / CI without systemctl
+	// the exec will fail with "executable file not found", which is exactly
+	// the production failure mode we want to defend against.
+	f.um.config.SkipServiceRestart = false
+
+	err := f.um.RollbackUpdate(context.Background(), f.updateID)
+	if err == nil {
+		t.Fatal("RollbackUpdate() returned nil, want error when restart fails")
+	}
+
+	if !f.rollbackAvailable(t) {
+		t.Fatal("rollback_available stayed at 0 after failed restart, want reset to 1 so operator can retry")
+	}
+	if got := f.status(t); got != string(StatusFailed) {
+		t.Fatalf("status = %q, want %q (must not be marked rolled_back when restart failed)", got, StatusFailed)
 	}
 }
 

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -313,9 +313,21 @@ func TestMarkUpdateFailed(t *testing.T) {
 	}
 }
 
-func TestRollbackUpdateRestoresBackup(t *testing.T) {
+// rollbackFixture wires up the on-disk and in-DB state needed to exercise
+// UpdateManager.RollbackUpdate without reaching for a real updater config
+// on each test.
+type rollbackFixture struct {
+	db         *sql.DB
+	um         *UpdateManager
+	updateID   int64
+	binaryPath string
+	backupDir  string
+}
+
+func newRollbackFixture(t *testing.T, status UpdateStatus, rollbackAvailable bool) *rollbackFixture {
+	t.Helper()
 	db := setupTestDB(t)
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
 	buildDir := t.TempDir()
 	binaryPath := filepath.Join(buildDir, "mailserver")
@@ -330,11 +342,17 @@ func TestRollbackUpdateRestoresBackup(t *testing.T) {
 		t.Fatalf("failed to write backup binary: %v", err)
 	}
 
-	if _, err := db.Exec(`INSERT INTO update_history (update_type, from_version, to_version, from_commit, to_commit, status, started_by, backup_path, rollback_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`, "release", "v1.0.0", "v1.1.0", "oldcommit", "newcommit", string(StatusFailed), "admin", backupDir); err != nil {
+	availableFlag := 0
+	if rollbackAvailable {
+		availableFlag = 1
+	}
+	res, err := db.Exec(`INSERT INTO update_history (update_type, from_version, to_version, from_commit, to_commit, status, started_by, backup_path, rollback_available) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"release", "v1.0.0", "v1.1.0", "oldcommit", "newcommit", string(status), "admin", backupDir, availableFlag)
+	if err != nil {
 		t.Fatalf("failed to insert update history: %v", err)
 	}
-	var updateID int64
-	if err := db.QueryRow(`SELECT id FROM update_history LIMIT 1`).Scan(&updateID); err != nil {
+	updateID, err := res.LastInsertId()
+	if err != nil {
 		t.Fatalf("failed to get update id: %v", err)
 	}
 	if _, err := db.Exec(`INSERT INTO rollback_snapshots (update_id, snapshot_type, version, commit_sha, binary_path, backup_path) VALUES (?, 'pre_update', ?, ?, ?, ?)`, updateID, "v1.0.0", "oldcommit", binaryPath, backupDir); err != nil {
@@ -347,30 +365,119 @@ func TestRollbackUpdateRestoresBackup(t *testing.T) {
 		BinaryPath:     binaryPath,
 		SystemdService: "mailserver.service",
 	}
-	um := NewUpdateManager(db, cfg, logging.Default(), nil)
+	return &rollbackFixture{
+		db:         db,
+		um:         NewUpdateManager(db, cfg, logging.Default(), nil),
+		updateID:   updateID,
+		binaryPath: binaryPath,
+		backupDir:  backupDir,
+	}
+}
 
-	if err := um.RollbackUpdate(context.Background(), updateID); err != nil {
+func (f *rollbackFixture) rollbackAvailable(t *testing.T) bool {
+	t.Helper()
+	var available bool
+	if err := f.db.QueryRow(`SELECT rollback_available FROM update_history WHERE id = ?`, f.updateID).Scan(&available); err != nil {
+		t.Fatalf("failed to query rollback_available: %v", err)
+	}
+	return available
+}
+
+func (f *rollbackFixture) status(t *testing.T) string {
+	t.Helper()
+	var status string
+	if err := f.db.QueryRow(`SELECT status FROM update_history WHERE id = ?`, f.updateID).Scan(&status); err != nil {
+		t.Fatalf("failed to query status: %v", err)
+	}
+	return status
+}
+
+func TestRollbackUpdateRestoresBackup(t *testing.T) {
+	f := newRollbackFixture(t, StatusFailed, true)
+
+	if err := f.um.RollbackUpdate(context.Background(), f.updateID); err != nil {
 		t.Fatalf("RollbackUpdate() error = %v", err)
 	}
 
-	data, err := os.ReadFile(binaryPath)
+	data, err := os.ReadFile(f.binaryPath)
 	if err != nil {
 		t.Fatalf("failed to read restored binary: %v", err)
 	}
 	if string(data) != "old binary" {
 		t.Fatalf("restored binary = %q, want %q", string(data), "old binary")
 	}
-
-	var status string
-	var rollbackAvailable bool
-	if err := db.QueryRow(`SELECT status, rollback_available FROM update_history WHERE id = ?`, updateID).Scan(&status, &rollbackAvailable); err != nil {
-		t.Fatalf("failed to query update history: %v", err)
+	if got := f.status(t); got != string(StatusRolledBack) {
+		t.Fatalf("status = %q, want %q", got, StatusRolledBack)
 	}
-	if status != string(StatusRolledBack) {
-		t.Fatalf("status = %q, want %q", status, StatusRolledBack)
-	}
-	if rollbackAvailable {
+	if f.rollbackAvailable(t) {
 		t.Fatal("rollback_available = true, want false")
+	}
+}
+
+// Second rollback of the same update must be rejected. The first call flips
+// rollback_available to 0 as part of its atomic claim; the second finds no
+// row to claim and returns an error without touching the binary.
+func TestRollbackUpdateRejectsDoubleRollback(t *testing.T) {
+	f := newRollbackFixture(t, StatusFailed, true)
+	ctx := context.Background()
+
+	if err := f.um.RollbackUpdate(ctx, f.updateID); err != nil {
+		t.Fatalf("first RollbackUpdate() error = %v", err)
+	}
+
+	// Overwrite the binary so we can detect whether the second rollback
+	// (wrongly) restored it again.
+	if err := os.WriteFile(f.binaryPath, []byte("post-rollback edit"), 0o750); err != nil {
+		t.Fatalf("failed to overwrite binary: %v", err)
+	}
+
+	if err := f.um.RollbackUpdate(ctx, f.updateID); err == nil {
+		t.Fatal("second RollbackUpdate() succeeded, want error")
+	}
+	data, err := os.ReadFile(f.binaryPath)
+	if err != nil {
+		t.Fatalf("failed to read binary: %v", err)
+	}
+	if string(data) != "post-rollback edit" {
+		t.Fatalf("binary was restored by second rollback: got %q", string(data))
+	}
+}
+
+// Rollback must refuse updates that are still in progress — pulling the
+// binary out from under a running deploy would corrupt on-disk state.
+func TestRollbackUpdateRefusesInProgressUpdate(t *testing.T) {
+	f := newRollbackFixture(t, StatusInProgress, true)
+
+	err := f.um.RollbackUpdate(context.Background(), f.updateID)
+	if err == nil {
+		t.Fatal("RollbackUpdate() on in-progress update succeeded, want error")
+	}
+	if !f.rollbackAvailable(t) {
+		t.Fatal("rollback_available cleared after refused rollback, want preserved")
+	}
+	if got := f.status(t); got != string(StatusInProgress) {
+		t.Fatalf("status = %q, want %q", got, StatusInProgress)
+	}
+}
+
+// If the restore itself fails, the claim must be released so the operator
+// can retry. Otherwise one bad attempt would permanently wedge the rollback.
+func TestRollbackUpdateReleasesClaimOnRestoreFailure(t *testing.T) {
+	f := newRollbackFixture(t, StatusFailed, true)
+
+	// Corrupt the backup so RestoreFromBackup fails.
+	if err := os.Remove(filepath.Join(f.backupDir, "mailserver-binary")); err != nil {
+		t.Fatalf("failed to remove backup binary: %v", err)
+	}
+
+	if err := f.um.RollbackUpdate(context.Background(), f.updateID); err == nil {
+		t.Fatal("RollbackUpdate() with missing backup succeeded, want error")
+	}
+	if !f.rollbackAvailable(t) {
+		t.Fatal("rollback_available = false after failed restore, want reset to true so operator can retry")
+	}
+	if got := f.status(t); got != string(StatusFailed) {
+		t.Fatalf("status = %q, want %q (unchanged on failed rollback)", got, StatusFailed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace the `rollbackUpdate` stub with a real restore path that calls `BackupManager.RestoreFromBackup` and marks the update as `rolled_back` with a completion timestamp.
- Record a `rollback_snapshots` row (and stamp `update_history.backup_path` / `rollback_available`) on every successful pre-update backup, giving rollback a durable pointer to the most recent snapshot.
- Wire the admin `POST /admin/system/update/rollback/{id}` endpoint to the new `UpdateManager.RollbackUpdate`, returning proper success/failure JSON and emitting `system_rollback` audit events for both outcomes.
- Auto-rollback after build/test/deploy/health-check failures now checks and logs the restore error instead of silently swallowing it.
- README gains a short "Current Limitations" section noting the new rollback behavior alongside remaining known gaps.

## Test plan
- [x] `go test -count=1 ./internal/updater/...` (rollback success + failure paths in `updater_test.go` and `integration_test.go`)
- [x] `go test -count=1 ./internal/admin/...` (handler success, handler failure, method-not-allowed, unauthorized)
- [x] `go vet ./internal/updater/... ./internal/admin/...`
- [x] `go build ./...`
- [ ] Manual: trigger a successful update, confirm `rollback_snapshots` row appears, then POST to the rollback endpoint and verify the binary is restored
- [ ] Manual: force a build/test failure and verify auto-rollback restores the prior binary and logs any restore error

## Notes
- Depends on `rollback_snapshots` and the `update_history.backup_path` / `rollback_available` columns, both of which already exist in migration `018_update_system.sql`.
- `UpdateManager` is constructed with a `nil` `*doctor.Doctor` in the rollback handler; rollback does not touch the doctor, but if a future refactor wires health checks into rollback, that construction needs to pass a real doctor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fenilsonani/email-server/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full rollback capability with an authenticated admin rollback API (POST) and a config option to skip service restarts.

* **Bug Fixes**
  * Improved rollback tracking, atomic claim/release behavior, clearer error handling, and more robust service-restart handling on failures.

* **Documentation**
  * Added a "Current Limitations" section to the README listing known outstanding issues.

* **Tests**
  * Expanded unit and integration tests covering rollback success/failure, auth, method validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->