### PR TITLE
fix: surface json.Unmarshal errors in store / auth code paths

### DIFF
--- a/internal/admin/features_handlers.go
+++ b/internal/admin/features_handlers.go
@@ -548,10 +548,27 @@ func (s *Server) handleScheduled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Count by status
-	pending, _ := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusPending)
-	sent, _ := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusSent)
-	cancelled, _ := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusCancelled)
+	// Count by status. ListScheduledEmails now returns an error when a row's
+	// recipients column has malformed JSON; surface those instead of letting
+	// corrupted data collapse silently into a zero count.
+	pending, err := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusPending)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "Failed to count pending scheduled emails", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	sent, err := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusSent)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "Failed to count sent scheduled emails", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	cancelled, err := s.featuresStore.ListScheduledEmails(r.Context(), userID, features.ScheduledStatusCancelled)
+	if err != nil {
+		s.logger.ErrorContext(r.Context(), "Failed to count cancelled scheduled emails", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 
 	data := map[string]interface{}{
 		"Title":          "Scheduled Emails",

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -139,9 +140,14 @@ func (s *Server) validateAPIKey(ctx context.Context, token string) (*APIKey, err
 		return nil, ErrInvalidAPIKey
 	}
 
-	// Parse scopes
+	// Parse scopes. A malformed scopes column would otherwise silently
+	// authenticate the request with zero permissions, leaving every
+	// downstream "permission denied" impossible to root-cause. Treat
+	// corruption as an auth failure so it surfaces in logs.
 	if scopesJSON != "" {
-		json.Unmarshal([]byte(scopesJSON), &apiKey.Scopes)
+		if err := json.Unmarshal([]byte(scopesJSON), &apiKey.Scopes); err != nil {
+			return nil, fmt.Errorf("api key %d has malformed scopes: %w", apiKey.ID, err)
+		}
 	}
 
 	if lastUsedAt.Valid {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// setupAPIKeyTestServer builds an in-memory SQLite Server with an api_keys
+// table populated with one valid key. Returns the server, the bare key
+// string the caller can pass to validateAPIKey, and the row ID so tests
+// can mutate the row before calling validateAPIKey.
+func setupAPIKeyTestServer(t *testing.T, scopesJSON string) (*Server, string, int64) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec(`
+		CREATE TABLE api_keys (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			domain_id INTEGER NOT NULL,
+			key_hash TEXT NOT NULL,
+			key_prefix TEXT NOT NULL,
+			name TEXT NOT NULL,
+			scopes TEXT NOT NULL,
+			is_active BOOLEAN DEFAULT TRUE,
+			rate_limit_per_hour INTEGER DEFAULT 1000,
+			last_used_at DATETIME,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			expires_at DATETIME,
+			key_salt TEXT
+		)
+	`); err != nil {
+		t.Fatalf("failed to create api_keys table: %v", err)
+	}
+
+	fullKey, prefix, hash, salt, err := GenerateAPIKey(true)
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+
+	res, err := db.Exec(`
+		INSERT INTO api_keys (domain_id, key_hash, key_prefix, name, scopes, is_active, rate_limit_per_hour, key_salt)
+		VALUES (1, ?, ?, 'test-key', ?, TRUE, 1000, ?)
+	`, hash, prefix, scopesJSON, salt)
+	if err != nil {
+		t.Fatalf("failed to insert api key row: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+
+	return &Server{db: db}, fullKey, id
+}
+
+// TestValidateAPIKey_RejectsMalformedScopes locks in the fix for the
+// previously-silent json.Unmarshal at middleware.go:144. Before the fix
+// a corrupted scopes column would silently authenticate the request
+// with apiKey.Scopes left as a nil slice — every downstream "permission
+// denied" was impossible to root-cause. Now it returns a wrapped error
+// so the request fails loudly and the corruption is observable in logs.
+func TestValidateAPIKey_RejectsMalformedScopes(t *testing.T) {
+	server, fullKey, _ := setupAPIKeyTestServer(t, "this-is-not-valid-json")
+
+	got, err := server.validateAPIKey(context.Background(), fullKey)
+	if err == nil {
+		t.Fatalf("validateAPIKey() returned nil error for malformed scopes; got key with scopes=%v", got.Scopes)
+	}
+	if got != nil {
+		t.Fatalf("validateAPIKey() returned non-nil APIKey on error: %#v", got)
+	}
+	if !strings.Contains(err.Error(), "malformed scopes") {
+		t.Fatalf("error message %q does not mention 'malformed scopes'", err.Error())
+	}
+}
+
+// TestValidateAPIKey_AcceptsValidScopes confirms the success path still
+// works after the error-handling change.
+func TestValidateAPIKey_AcceptsValidScopes(t *testing.T) {
+	server, fullKey, _ := setupAPIKeyTestServer(t, `["email:send","email:read"]`)
+
+	apiKey, err := server.validateAPIKey(context.Background(), fullKey)
+	if err != nil {
+		t.Fatalf("validateAPIKey() error = %v, want nil", err)
+	}
+	if apiKey == nil {
+		t.Fatal("validateAPIKey() returned nil APIKey")
+	}
+	if len(apiKey.Scopes) != 2 || apiKey.Scopes[0] != "email:send" || apiKey.Scopes[1] != "email:read" {
+		t.Fatalf("scopes mismatch: got %#v, want [email:send email:read]", apiKey.Scopes)
+	}
+}
+
+// TestValidateAPIKey_AcceptsEmptyScopes confirms a key with no scopes
+// (the "" sentinel that skips Unmarshal entirely) still authenticates.
+func TestValidateAPIKey_AcceptsEmptyScopes(t *testing.T) {
+	server, fullKey, _ := setupAPIKeyTestServer(t, "")
+
+	apiKey, err := server.validateAPIKey(context.Background(), fullKey)
+	if err != nil {
+		t.Fatalf("validateAPIKey() error = %v, want nil", err)
+	}
+	if len(apiKey.Scopes) != 0 {
+		t.Fatalf("expected empty scopes, got %#v", apiKey.Scopes)
+	}
+}
+

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -20,6 +20,13 @@ func setupAPIKeyTestServer(t *testing.T, scopesJSON string) (*Server, string, in
 	if err != nil {
 		t.Fatalf("failed to open sqlite db: %v", err)
 	}
+	// With github.com/mattn/go-sqlite3 the ":memory:" DSN gives each
+	// connection its own private in-memory database, so a multi-connection
+	// pool can read/write completely different DBs. Pin to one connection
+	// for tests so the schema and rows we insert here are visible to
+	// validateAPIKey on the other side.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec(`
@@ -72,6 +79,11 @@ func TestValidateAPIKey_RejectsMalformedScopes(t *testing.T) {
 
 	got, err := server.validateAPIKey(context.Background(), fullKey)
 	if err == nil {
+		// Guard against the (nil, nil) regression before reading .Scopes,
+		// otherwise the test would panic instead of failing cleanly.
+		if got == nil {
+			t.Fatal("validateAPIKey() returned (nil, nil) for malformed scopes; want non-nil error")
+		}
 		t.Fatalf("validateAPIKey() returned nil error for malformed scopes; got key with scopes=%v", got.Scopes)
 	}
 	if got != nil {
@@ -107,6 +119,9 @@ func TestValidateAPIKey_AcceptsEmptyScopes(t *testing.T) {
 	apiKey, err := server.validateAPIKey(context.Background(), fullKey)
 	if err != nil {
 		t.Fatalf("validateAPIKey() error = %v, want nil", err)
+	}
+	if apiKey == nil {
+		t.Fatal("validateAPIKey() returned nil APIKey")
 	}
 	if len(apiKey.Scopes) != 0 {
 		t.Fatalf("expected empty scopes, got %#v", apiKey.Scopes)

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -33,8 +33,13 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request, domainID 
 
 		err := rows.Scan(&t.ID, &t.Slug, &t.Name, &t.Subject, &htmlBody, &textBody, &variablesJSON, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 		if err != nil {
-			s.logger.WarnContext(r.Context(), "skipping template row with scan error", "domain_id", domainID, "error", err)
-			continue
+			// Scan errors signal a query/schema/type mismatch or driver-level
+			// read failure — not a row-level data problem we can skip past.
+			// Surface them as a 500 so a broken deployment doesn't quietly
+			// return a partial template list.
+			s.logger.ErrorContext(r.Context(), "template row scan failed", err, "domain_id", domainID)
+			jsonError(w, "Internal server error", "INTERNAL_ERROR", http.StatusInternalServerError)
+			return
 		}
 
 		if htmlBody.Valid {

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"html"
 	"net/http"
 	"regexp"
@@ -32,6 +33,7 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request, domainID 
 
 		err := rows.Scan(&t.ID, &t.Slug, &t.Name, &t.Subject, &htmlBody, &textBody, &variablesJSON, &t.IsActive, &t.CreatedAt, &t.UpdatedAt)
 		if err != nil {
+			s.logger.WarnContext(r.Context(), "skipping template row with scan error", "domain_id", domainID, "error", err)
 			continue
 		}
 
@@ -42,7 +44,10 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request, domainID 
 			t.TextBody = textBody.String
 		}
 		if variablesJSON.Valid && variablesJSON.String != "" {
-			json.Unmarshal([]byte(variablesJSON.String), &t.Variables)
+			if err := json.Unmarshal([]byte(variablesJSON.String), &t.Variables); err != nil {
+				s.logger.WarnContext(r.Context(), "skipping template with malformed variables JSON", "template_id", t.ID, "domain_id", domainID, "error", err)
+				continue
+			}
 		}
 
 		t.DomainID = domainID
@@ -238,7 +243,9 @@ func (s *Server) getTemplateBySlug(ctx context.Context, domainID int64, slug str
 		t.TextBody = textBody.String
 	}
 	if variablesJSON.Valid && variablesJSON.String != "" {
-		json.Unmarshal([]byte(variablesJSON.String), &t.Variables)
+		if err := json.Unmarshal([]byte(variablesJSON.String), &t.Variables); err != nil {
+			return nil, fmt.Errorf("template %q has malformed variables: %w", t.Slug, err)
+		}
 	}
 
 	t.DomainID = domainID

--- a/internal/features/store.go
+++ b/internal/features/store.go
@@ -360,8 +360,12 @@ func (s *Store) GetScheduledEmail(ctx context.Context, userID, emailID int64) (*
 		return nil, err
 	}
 
-	json.Unmarshal([]byte(recipientsJSON), &email.Recipients)
-	json.Unmarshal([]byte(headersJSON), &email.Headers)
+	if err := json.Unmarshal([]byte(recipientsJSON), &email.Recipients); err != nil {
+		return nil, fmt.Errorf("scheduled email %d has malformed recipients: %w", email.ID, err)
+	}
+	if err := json.Unmarshal([]byte(headersJSON), &email.Headers); err != nil {
+		return nil, fmt.Errorf("scheduled email %d has malformed headers: %w", email.ID, err)
+	}
 	if sentAt.Valid {
 		email.SentAt = sentAt.Time
 	}
@@ -397,7 +401,9 @@ func (s *Store) ListScheduledEmails(ctx context.Context, userID int64, status st
 		if err != nil {
 			return nil, err
 		}
-		json.Unmarshal([]byte(recipientsJSON), &e.Recipients)
+		if err := json.Unmarshal([]byte(recipientsJSON), &e.Recipients); err != nil {
+			return nil, fmt.Errorf("scheduled email %d has malformed recipients: %w", e.ID, err)
+		}
 		emails = append(emails, e)
 	}
 	return emails, rows.Err()
@@ -427,10 +433,14 @@ func (s *Store) GetPendingScheduledEmails(ctx context.Context) ([]*ScheduledEmai
 			return nil, err
 		}
 		if recipientsJSON.Valid {
-			json.Unmarshal([]byte(recipientsJSON.String), &e.Recipients)
+			if err := json.Unmarshal([]byte(recipientsJSON.String), &e.Recipients); err != nil {
+				return nil, fmt.Errorf("scheduled email %d has malformed recipients: %w", e.ID, err)
+			}
 		}
 		if headersJSON.Valid {
-			json.Unmarshal([]byte(headersJSON.String), &e.Headers)
+			if err := json.Unmarshal([]byte(headersJSON.String), &e.Headers); err != nil {
+				return nil, fmt.Errorf("scheduled email %d has malformed headers: %w", e.ID, err)
+			}
 		}
 		emails = append(emails, e)
 	}
@@ -649,10 +659,14 @@ func (s *Store) GetReadyPendingSends(ctx context.Context) ([]*PendingSend, error
 			return nil, err
 		}
 		if recipientsJSON.Valid {
-			json.Unmarshal([]byte(recipientsJSON.String), &p.Recipients)
+			if err := json.Unmarshal([]byte(recipientsJSON.String), &p.Recipients); err != nil {
+				return nil, fmt.Errorf("pending send %d has malformed recipients: %w", p.ID, err)
+			}
 		}
 		if headersJSON.Valid {
-			json.Unmarshal([]byte(headersJSON.String), &p.Headers)
+			if err := json.Unmarshal([]byte(headersJSON.String), &p.Headers); err != nil {
+				return nil, fmt.Errorf("pending send %d has malformed headers: %w", p.ID, err)
+			}
 		}
 		pending = append(pending, p)
 	}

--- a/internal/org/org.go
+++ b/internal/org/org.go
@@ -131,7 +131,9 @@ func (s *Store) Get(ctx context.Context, id int64) (*Organization, error) {
 	if err != nil {
 		return nil, err
 	}
-	json.Unmarshal([]byte(settingsJSON), &org.Settings)
+	if err := json.Unmarshal([]byte(settingsJSON), &org.Settings); err != nil {
+		return nil, fmt.Errorf("organization %d has malformed settings: %w", org.ID, err)
+	}
 	return org, nil
 }
 
@@ -149,7 +151,9 @@ func (s *Store) GetBySlug(ctx context.Context, slug string) (*Organization, erro
 	if err != nil {
 		return nil, err
 	}
-	json.Unmarshal([]byte(settingsJSON), &org.Settings)
+	if err := json.Unmarshal([]byte(settingsJSON), &org.Settings); err != nil {
+		return nil, fmt.Errorf("organization %q has malformed settings: %w", org.Slug, err)
+	}
 	return org, nil
 }
 
@@ -170,7 +174,9 @@ func (s *Store) List(ctx context.Context) ([]Organization, error) {
 		if err := rows.Scan(&o.ID, &o.Name, &o.Slug, &o.OwnerUserID, &o.Preset, &settingsJSON, &o.CreatedAt, &o.UpdatedAt); err != nil {
 			return nil, err
 		}
-		json.Unmarshal([]byte(settingsJSON), &o.Settings)
+		if err := json.Unmarshal([]byte(settingsJSON), &o.Settings); err != nil {
+			return nil, fmt.Errorf("organization %d has malformed settings: %w", o.ID, err)
+		}
 		orgs = append(orgs, o)
 	}
 	return orgs, nil
@@ -196,7 +202,9 @@ func (s *Store) ListByUser(ctx context.Context, userID int64) ([]Organization, e
 		if err := rows.Scan(&o.ID, &o.Name, &o.Slug, &o.OwnerUserID, &o.Preset, &settingsJSON, &o.CreatedAt, &o.UpdatedAt); err != nil {
 			return nil, err
 		}
-		json.Unmarshal([]byte(settingsJSON), &o.Settings)
+		if err := json.Unmarshal([]byte(settingsJSON), &o.Settings); err != nil {
+			return nil, fmt.Errorf("organization %d has malformed settings: %w", o.ID, err)
+		}
 		orgs = append(orgs, o)
 	}
 	return orgs, nil


### PR DESCRIPTION
## Summary

Audited every \`json.Unmarshal\` call in \`internal/\` and found 14 in production code where the return value was being silently discarded. Each one decodes a JSON column off a row we *just* successfully scanned, so any failure means the on-disk JSON is corrupted (migration bug, manual edit, encoding issue) — not something the application can recover from by guessing.

The most dangerous was \`internal/api/middleware.go:144\` on the API key auth hot path. A malformed \`scopes\` column would silently authenticate the request with \`apiKey.Scopes\` left as a nil slice, leaving every subsequent \"permission denied\" impossible to root-cause.

Brings the rest of the codebase in line with the pattern already used in \`internal/api/scheduler.go:131\`, \`internal/api/webhooks.go\` (2 sites), and \`internal/queue/redis.go:722\`, all of which already check and return the error.

## Changes

| File | Sites | Function(s) | Behaviour |
|---|---|---|---|
| \`internal/api/middleware.go\` | 1 | \`validateAPIKey\` | Returns \`fmt.Errorf(\"api key %d has malformed scopes: %w\", id, err)\`. Auth fails loudly. |
| \`internal/api/templates.go\` | 2 | \`listTemplates\`, \`getTemplateBySlug\` | List handler logs at WARN and skips the bad row (one corrupt template doesn't break the whole list). Singular getter returns wrapped error. |
| \`internal/org/org.go\` | 4 | \`Get\`, \`GetBySlug\`, \`List\`, \`ListByUser\` | All return wrapped errors with the org id/slug. |
| \`internal/features/store.go\` | 7 | \`GetScheduledEmail\`, \`ListScheduledEmails\`, \`GetPendingScheduledEmails\`, \`GetReadyPendingSends\` | All return wrapped errors with the row id, distinguishing recipients vs headers. |

The only remaining silent \`json.Unmarshal\` in \`internal/\` is in \`internal/queue/queue_benchmark_test.go\`, which is benchmark code that deliberately ignores errors for measurement purposes.

## New tests

Adds \`internal/api/middleware_test.go\` with three regression tests on \`validateAPIKey\`:

- \`TestValidateAPIKey_RejectsMalformedScopes\` — inserts an api_keys row with non-JSON \`scopes\`, asserts \`validateAPIKey\` returns a non-nil error mentioning \"malformed scopes\" and a nil APIKey.
- \`TestValidateAPIKey_AcceptsValidScopes\` — happy path with \`[\"email:send\",\"email:read\"]\`.
- \`TestValidateAPIKey_AcceptsEmptyScopes\` — empty-string sentinel that skips Unmarshal entirely.

Test harness uses in-memory SQLite + the existing \`GenerateAPIKey\` helper to produce a real key/hash/salt tuple, matching the convention of \`internal/api/suppression_test.go\`.

## Test plan

- [x] \`go test -count=1 ./internal/api/... ./internal/org/... ./internal/features/...\`
- [x] \`go test -count=1 ./...\` — every package green (37 packages)
- [x] \`go vet ./...\` — clean
- [x] \`go build ./...\` — clean
- [x] \`grep -rn 'json.Unmarshal(' internal/ | grep -v '_test.go'\` — verified no silent calls remain in production code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fenilsonani/email-server/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive test coverage for API key validation scenarios.

* **Bug Fixes**
  * Improved error handling for malformed JSON in API key validation.
  * Fixed silent failures in template processing to properly report parsing errors.
  * Fixed silent failures in scheduled email data handling to properly report parsing errors.
  * Fixed silent failures in organization settings to properly report parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->