### PR TITLE
fix(setup): repair end-to-end setup wizard (refs #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ git clone https://github.com/fenilsonani/email-server.git
 cd email-server
 go build -o mailserver ./cmd/mailserver
 
-./mailserver preflight    # check prerequisites
-./mailserver setup        # interactive setup
-./mailserver doctor       # diagnose issues
+sudo ./mailserver preflight    # check prerequisites
+sudo ./mailserver setup        # interactive setup (installs to /usr/local/bin/mailserver)
+mailserver doctor              # diagnose issues
 ```
+
+The wizard runs `preflight`, generates config, creates the system user/dirs,
+generates DKIM keys, runs migrations, creates the admin user, copies itself to
+`/usr/local/bin/mailserver`, installs the systemd unit, and starts the service.
 
 ### Manual Setup
 

--- a/cmd/mailserver/main.go
+++ b/cmd/mailserver/main.go
@@ -83,9 +83,12 @@ func main() {
 	}
 }
 
+const mailserverVersion = "0.1.0"
+
 var rootCmd = &cobra.Command{
-	Use:   "mailserver",
-	Short: "Personal email server with IMAP, SMTP, CalDAV, and CardDAV",
+	Use:     "mailserver",
+	Version: mailserverVersion,
+	Short:   "Personal email server with IMAP, SMTP, CalDAV, and CardDAV",
 	Long: `A personal email server supporting:
 - IMAP with IDLE for Apple Mail sync
 - SMTP for sending and receiving email
@@ -93,8 +96,12 @@ var rootCmd = &cobra.Command{
 - CardDAV for contacts sync
 - Multiple domains with DKIM signing`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Skip config loading for help commands
+		// Skip config loading for help/version (--version handled by cobra before RunE,
+		// but PreRunE still fires)
 		if cmd.Name() == "help" || cmd.Name() == "version" {
+			return nil
+		}
+		if v, _ := cmd.Flags().GetBool("version"); v {
 			return nil
 		}
 
@@ -1014,13 +1021,39 @@ var userCmd = &cobra.Command{
 	Short: "Manage email users",
 }
 
+var (
+	userAddPasswordHash string
+	userAddAdmin        bool
+)
+
 var userAddCmd = &cobra.Command{
-	Use:   "add <email> <password>",
+	Use:   "add <email> [password]",
 	Short: "Add a new user",
-	Args:  cobra.ExactArgs(2),
+	Long: `Add a new user.
+
+Password may be supplied as the second positional argument, or as a pre-hashed
+bcrypt string via --password-hash (preferred for scripted use, since flags are
+less likely to leak via process listings than positional args). Exactly one of
+the two must be provided.`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
-		password := args[1]
+
+		var hash string
+		switch {
+		case userAddPasswordHash != "" && len(args) == 2:
+			return fmt.Errorf("provide either a positional password or --password-hash, not both")
+		case userAddPasswordHash != "":
+			hash = userAddPasswordHash
+		case len(args) == 2:
+			h, err := auth.HashPassword(args[1])
+			if err != nil {
+				return fmt.Errorf("failed to hash password: %w", err)
+			}
+			hash = h
+		default:
+			return fmt.Errorf("password required: pass it as the second argument or via --password-hash")
+		}
 
 		if err := cfg.EnsureDirectories(); err != nil {
 			return err
@@ -1051,16 +1084,10 @@ var userAddCmd = &cobra.Command{
 			return fmt.Errorf("domain '%s' not found. Add it first with: mailserver domain add %s", domain, domain)
 		}
 
-		// Hash password
-		hash, err := auth.HashPassword(password)
-		if err != nil {
-			return fmt.Errorf("failed to hash password: %w", err)
-		}
-
 		// Insert user
 		result, err := db.ExecContext(context.Background(),
-			"INSERT INTO users (domain_id, username, password_hash) VALUES (?, ?, ?)",
-			domainID, username, hash,
+			"INSERT INTO users (domain_id, username, password_hash, is_admin) VALUES (?, ?, ?, ?)",
+			domainID, username, hash, userAddAdmin,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to add user: %w", err)
@@ -2796,7 +2823,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("mailserver v0.1.0")
+		fmt.Printf("mailserver v%s\n", mailserverVersion)
 	},
 }
 
@@ -3518,6 +3545,8 @@ func init() {
 	rootCmd.AddCommand(domainCmd)
 
 	// User commands
+	userAddCmd.Flags().StringVar(&userAddPasswordHash, "password-hash", "", "Pre-hashed bcrypt password (alternative to positional password)")
+	userAddCmd.Flags().BoolVar(&userAddAdmin, "admin", false, "Mark the user as a server admin")
 	userDeleteCmd.Flags().BoolVar(&userDeleteForce, "force", false, "Skip confirmation prompt")
 	userSetRoleCmd.Flags().StringVar(&setRoleDomain, "domain", "", "Domain scope for domain_admin role")
 	userCmd.AddCommand(userAddCmd)

--- a/cmd/mailserver/main.go
+++ b/cmd/mailserver/main.go
@@ -1032,9 +1032,10 @@ var userAddCmd = &cobra.Command{
 	Long: `Add a new user.
 
 Password may be supplied as the second positional argument, or as a pre-hashed
-bcrypt string via --password-hash (preferred for scripted use, since flags are
-less likely to leak via process listings than positional args). Exactly one of
-the two must be provided.`,
+argon2id string via --password-hash (preferred for scripted use: the value passed
+is already a non-reversible hash, so even if the command line is observed via
+process listings the plaintext password is not exposed). Exactly one of the two
+must be provided.`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
@@ -3545,7 +3546,7 @@ func init() {
 	rootCmd.AddCommand(domainCmd)
 
 	// User commands
-	userAddCmd.Flags().StringVar(&userAddPasswordHash, "password-hash", "", "Pre-hashed bcrypt password (alternative to positional password)")
+	userAddCmd.Flags().StringVar(&userAddPasswordHash, "password-hash", "", "Pre-hashed argon2id password (alternative to positional password)")
 	userAddCmd.Flags().BoolVar(&userAddAdmin, "admin", false, "Mark the user as a server admin")
 	userDeleteCmd.Flags().BoolVar(&userDeleteForce, "force", false, "Skip confirmation prompt")
 	userSetRoleCmd.Flags().StringVar(&setRoleDomain, "domain", "", "Domain scope for domain_admin role")

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,6 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
-github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -17,8 +17,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fenilsonani/email-server/internal/auth"
 	"github.com/fenilsonani/email-server/internal/validation"
-	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 )
 
@@ -391,7 +391,10 @@ func verifyDatabase(cfg *SetupConfig) error {
 }
 
 func createAdminUser(cfg *SetupConfig) error {
-	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.AdminPass), bcrypt.DefaultCost)
+	// Use auth.HashPassword (argon2id) so the hash matches what
+	// internal/auth.VerifyPassword expects — bcrypt hashes are silently
+	// rejected and would leave the admin unable to log in.
+	hash, err := auth.HashPassword(cfg.AdminPass)
 	if err != nil {
 		return err
 	}
@@ -410,7 +413,7 @@ func createAdminUser(cfg *SetupConfig) error {
 		}
 	}
 
-	cmd = exec.Command(exe, "user", "add", cfg.AdminEmail, "--password-hash", string(hash), "--admin", "--config", configPath) // #nosec G204 -- exe is os.Executable, args validated
+	cmd = exec.Command(exe, "user", "add", cfg.AdminEmail, "--password-hash", hash, "--admin", "--config", configPath) // #nosec G204 -- exe is os.Executable, args validated
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to add admin user: %w: %s", err, strings.TrimSpace(string(output)))
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
 	"net/mail"
 	"os"
@@ -154,6 +155,7 @@ func RunSetupWithOptions(force bool) error {
 		{Name: "Generate DKIM keys", Action: generateDKIM, Verify: verifyDKIM},
 		{Name: "Initialize database", Action: initDatabase, Verify: verifyDatabase},
 		{Name: "Create admin user", Action: createAdminUser, Verify: verifyAdminUser},
+		{Name: "Install binary", Action: installBinary, Verify: verifyInstalledBinary},
 		{Name: "Install systemd service", Action: installSystemd, Verify: verifySystemd},
 		{Name: "Start service", Action: startService, Verify: verifyService},
 	}
@@ -251,24 +253,29 @@ func generateConfig(cfg *SetupConfig) error {
 		return nil
 	}
 
+	dkimKeyFile := cfg.ConfigDir + "/dkim/" + cfg.Domain + ".key"
+
 	config := map[string]interface{}{
 		"server": map[string]interface{}{
 			"hostname": cfg.Hostname,
 			"domain":   cfg.Domain,
 		},
-		"domains": []string{cfg.Domain},
+		"domains": []map[string]interface{}{
+			{
+				"name":          cfg.Domain,
+				"dkim_selector": "mail",
+				"dkim_key_file": dkimKeyFile,
+			},
+		},
 		"storage": map[string]interface{}{
+			"data_dir":      cfg.DataDir,
 			"database_path": cfg.DataDir + "/mail.db",
 			"maildir_path":  cfg.DataDir + "/maildir",
 		},
 		"tls": map[string]interface{}{
-			"auto_cert":      true,
-			"acme_email":     cfg.TLSEmail,
-			"acme_cache_dir": cfg.DataDir + "/acme",
-		},
-		"dkim": map[string]interface{}{
-			"selector": "mail",
-			"key_path": cfg.ConfigDir + "/dkim/" + cfg.Domain + ".key",
+			"auto_tls":  true,
+			"email":     cfg.TLSEmail,
+			"cache_dir": cfg.DataDir + "/acme",
 		},
 		"queue": map[string]interface{}{
 			"redis_url": "redis://localhost:6379/0",
@@ -294,45 +301,59 @@ func verifyConfig(cfg *SetupConfig) error {
 	return err
 }
 
-// generateDKIM generates DKIM keys for the primary domain during initial setup.
-// Additional domains added via the admin panel get their DKIM keys generated separately.
+// generateDKIM generates DKIM keys for the primary domain during initial setup
+// and chowns them to the mailserver user so the daemon can read them at runtime.
+// Additional domains added later get their DKIM keys generated separately.
 func generateDKIM(cfg *SetupConfig) error {
-	keyPath := cfg.ConfigDir + "/dkim/" + cfg.Domain + ".key"
+	dkimDir := cfg.ConfigDir + "/dkim"
+	keyPath := dkimDir + "/" + cfg.Domain + ".key"
+	pubKeyPath := dkimDir + "/" + cfg.Domain + ".pub"
 
-	// Check if key already exists
-	if _, err := os.Stat(keyPath); err == nil {
-		return nil
+	if _, err := os.Stat(keyPath); err != nil {
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+
+		privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+		})
+		if err := os.WriteFile(keyPath, privateKeyPEM, 0600); err != nil {
+			return err
+		}
+
+		publicKeyDER, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+		if err != nil {
+			return err
+		}
+		publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: publicKeyDER,
+		})
+		if err := os.WriteFile(pubKeyPath, publicKeyPEM, 0644); err != nil {
+			return err
+		}
 	}
 
-	// Generate RSA key
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	// The daemon runs as the `mailserver` user and config validation requires
+	// the key file to be readable. The key dir lives under cfg.ConfigDir which
+	// is otherwise root-owned, so chown the dkim subtree explicitly.
+	u, err := user.Lookup("mailserver")
 	if err != nil {
 		return err
 	}
-
-	// Encode private key
-	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-	})
-
-	if err := os.WriteFile(keyPath, privateKeyPEM, 0600); err != nil {
-		return err
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+	for _, p := range []string{dkimDir, keyPath, pubKeyPath} {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		if err := os.Chown(p, uid, gid); err != nil {
+			return fmt.Errorf("chown %s: %w", p, err)
+		}
 	}
-
-	// Generate public key for DNS
-	publicKeyDER, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-	if err != nil {
-		return err
-	}
-
-	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: publicKeyDER,
-	})
-
-	pubKeyPath := cfg.ConfigDir + "/dkim/" + cfg.Domain + ".pub"
-	return os.WriteFile(pubKeyPath, publicKeyPEM, 0644)
+	return nil
 }
 
 func verifyDKIM(cfg *SetupConfig) error {
@@ -341,9 +362,23 @@ func verifyDKIM(cfg *SetupConfig) error {
 	return err
 }
 
+// selfExe returns the absolute path of the running mailserver binary, so
+// child invocations don't depend on `mailserver` being on $PATH (sudo's
+// secure_path will typically strip the build dir).
+func selfExe() (string, error) {
+	p, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locate self executable: %w", err)
+	}
+	return p, nil
+}
+
 func initDatabase(cfg *SetupConfig) error {
-	// Run migrations
-	cmd := exec.Command("mailserver", "migrate", "--config", cfg.ConfigDir+"/config.yaml") // #nosec G204 -- config path validated and exec.Command does not invoke a shell
+	exe, err := selfExe()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, "migrate", "--config", cfg.ConfigDir+"/config.yaml") // #nosec G204 -- exe is os.Executable, args validated
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -356,15 +391,18 @@ func verifyDatabase(cfg *SetupConfig) error {
 }
 
 func createAdminUser(cfg *SetupConfig) error {
-	// Hash password
 	hash, err := bcrypt.GenerateFromPassword([]byte(cfg.AdminPass), bcrypt.DefaultCost)
 	if err != nil {
 		return err
 	}
 
-	// Use mailserver CLI to add domain and user
-	// First add domain
-	cmd := exec.Command("mailserver", "domain", "add", cfg.Domain, "--config", cfg.ConfigDir+"/config.yaml") // #nosec G204 -- setup inputs validated and exec.Command does not invoke a shell
+	exe, err := selfExe()
+	if err != nil {
+		return err
+	}
+	configPath := cfg.ConfigDir + "/config.yaml"
+
+	cmd := exec.Command(exe, "domain", "add", cfg.Domain, "--config", configPath) // #nosec G204 -- exe is os.Executable, args validated
 	if output, err := cmd.CombinedOutput(); err != nil {
 		message := strings.ToLower(strings.TrimSpace(string(output)))
 		if !strings.Contains(message, "already exists") {
@@ -372,13 +410,67 @@ func createAdminUser(cfg *SetupConfig) error {
 		}
 	}
 
-	// Add user
-	cmd = exec.Command("mailserver", "user", "add", cfg.AdminEmail, "--password-hash", string(hash), "--admin", "--config", cfg.ConfigDir+"/config.yaml") // #nosec G204 -- setup inputs validated and exec.Command does not invoke a shell
-	return cmd.Run()
+	cmd = exec.Command(exe, "user", "add", cfg.AdminEmail, "--password-hash", string(hash), "--admin", "--config", configPath) // #nosec G204 -- exe is os.Executable, args validated
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to add admin user: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
 }
 
 func verifyAdminUser(cfg *SetupConfig) error {
 	// Just verify the command ran - actual verification would need DB check
+	return nil
+}
+
+const installedBinaryPath = "/usr/local/bin/mailserver"
+
+// installBinary copies the running binary to /usr/local/bin/mailserver so that
+// the systemd unit (which references that path) can start the service. If the
+// running binary is already at the install path, this is a no-op.
+func installBinary(cfg *SetupConfig) error {
+	src, err := selfExe()
+	if err != nil {
+		return err
+	}
+	if src == installedBinaryPath {
+		return nil
+	}
+
+	in, err := os.Open(src) // #nosec G304 -- src is os.Executable
+	if err != nil {
+		return fmt.Errorf("open self binary: %w", err)
+	}
+	defer in.Close()
+
+	tmp := installedBinaryPath + ".new"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmp, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("copy binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, installedBinaryPath); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("install %s: %w", installedBinaryPath, err)
+	}
+	return nil
+}
+
+func verifyInstalledBinary(cfg *SetupConfig) error {
+	info, err := os.Stat(installedBinaryPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("%s is not executable", installedBinaryPath)
+	}
 	return nil
 }
 
@@ -435,12 +527,20 @@ func startService(cfg *SetupConfig) error {
 }
 
 func verifyService(cfg *SetupConfig) error {
-	// Check if service is running by checking ports
-	ports := []int{25, 143}
-	for _, port := range ports {
+	// Ask systemd directly: is-active returns exit 0 only when active. This
+	// catches the case where the unit failed to start (e.g. binary missing or
+	// config rejected) instead of waiting for ports that may never open.
+	out, err := exec.Command("systemctl", "is-active", "mailserver").CombinedOutput() // #nosec G204 -- static command without shell
+	state := strings.TrimSpace(string(out))
+	if err != nil || state != "active" {
+		return fmt.Errorf("service not active (state=%q): try `journalctl -u mailserver -n 50` for details", state)
+	}
+
+	// Belt-and-suspenders: confirm at least one mail port is listening.
+	for _, port := range []int{25, 143} {
 		conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 		if err != nil {
-			return fmt.Errorf("service not listening on port %d", port)
+			return fmt.Errorf("service active but not listening on port %d: %w", port, err)
 		}
 		conn.Close()
 	}
@@ -473,7 +573,7 @@ func printSuccess(cfg *SetupConfig) {
 	fmt.Printf("  TXT   _dmarc.%s  →  v=DMARC1; p=quarantine; rua=mailto:postmaster@%s\n", cfg.Domain, cfg.Domain)
 	fmt.Println()
 	fmt.Println("For DKIM record, run:")
-	fmt.Printf("  mailserver dkim show --domain %s\n", cfg.Domain)
+	fmt.Printf("  mailserver dkim show %s\n", cfg.Domain)
 	fmt.Println()
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	fmt.Println("                    NEXT STEPS")

--- a/internal/setup/setup_generate_test.go
+++ b/internal/setup/setup_generate_test.go
@@ -1,0 +1,150 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fenilsonani/email-server/internal/config"
+)
+
+// TestGenerateConfig_RoundtripsThroughConfigLoad guards against the class of
+// bugs reported in issue #46: the wizard wrote YAML that the runtime config
+// loader either rejected outright (`domains[0]` schema mismatch) or silently
+// dropped (TLS keys under wrong names, bogus top-level `dkim:` block). Any
+// regression where setup emits keys that don't match the koanf-tagged Config
+// struct will now fail this test.
+func TestGenerateConfig_RoundtripsThroughConfigLoad(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "etc")
+	dataDir := filepath.Join(tmp, "var")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir configDir: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("mkdir dataDir: %v", err)
+	}
+
+	cfg := &SetupConfig{
+		Domain:     "example.com",
+		Hostname:   "mail.example.com",
+		AdminEmail: "admin@example.com",
+		AdminPass:  "irrelevant",
+		TLSEmail:   "tls@example.com",
+		DataDir:    dataDir,
+		ConfigDir:  configDir,
+	}
+
+	if err := generateConfig(cfg); err != nil {
+		t.Fatalf("generateConfig: %v", err)
+	}
+
+	loaded, err := config.Load(filepath.Join(configDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("config.Load failed (the wizard emitted a YAML the runtime can't parse): %v", err)
+	}
+
+	// Bug 2: domains were written as strings instead of []DomainConfig.
+	if got := len(loaded.Domains); got != 1 {
+		t.Fatalf("Domains = %d entries, want 1", got)
+	}
+	d := loaded.Domains[0]
+	if d.Name != "example.com" {
+		t.Errorf("Domains[0].Name = %q, want %q", d.Name, "example.com")
+	}
+	if d.DKIMSelector != "mail" {
+		t.Errorf("Domains[0].DKIMSelector = %q, want %q", d.DKIMSelector, "mail")
+	}
+	wantKey := filepath.Join(configDir, "dkim", "example.com.key")
+	if d.DKIMKeyFile != wantKey {
+		t.Errorf("Domains[0].DKIMKeyFile = %q, want %q", d.DKIMKeyFile, wantKey)
+	}
+
+	// Bug 3: TLS keys were `auto_cert`/`acme_email`/`acme_cache_dir`, none of
+	// which match the schema, so user answers were silently discarded.
+	if !loaded.TLS.AutoTLS {
+		t.Error("TLS.AutoTLS = false, want true (user TLS answer was silently dropped)")
+	}
+	if loaded.TLS.Email != "tls@example.com" {
+		t.Errorf("TLS.Email = %q, want %q", loaded.TLS.Email, "tls@example.com")
+	}
+	wantCache := filepath.Join(dataDir, "acme")
+	if loaded.TLS.CacheDir != wantCache {
+		t.Errorf("TLS.CacheDir = %q, want %q", loaded.TLS.CacheDir, wantCache)
+	}
+
+	// Server + storage round-trip sanity.
+	if loaded.Server.Hostname != "mail.example.com" {
+		t.Errorf("Server.Hostname = %q, want %q", loaded.Server.Hostname, "mail.example.com")
+	}
+	if loaded.Server.Domain != "example.com" {
+		t.Errorf("Server.Domain = %q, want %q", loaded.Server.Domain, "example.com")
+	}
+	if want := filepath.Join(dataDir, "mail.db"); loaded.Storage.DatabasePath != want {
+		t.Errorf("Storage.DatabasePath = %q, want %q", loaded.Storage.DatabasePath, want)
+	}
+	if want := filepath.Join(dataDir, "maildir"); loaded.Storage.MaildirPath != want {
+		t.Errorf("Storage.MaildirPath = %q, want %q", loaded.Storage.MaildirPath, want)
+	}
+
+	if loaded.Queue.RedisURL == "" {
+		t.Error("Queue.RedisURL empty after load")
+	}
+	if !loaded.Admin.Enabled {
+		t.Error("Admin.Enabled = false, want true")
+	}
+}
+
+// TestGenerateConfig_KeepsExistingConfig verifies the idempotency branch:
+// re-running setup against an existing config.yaml should not clobber it.
+func TestGenerateConfig_KeepsExistingConfig(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "etc")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	existing := []byte("# pre-existing config\n")
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, existing, 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cfg := &SetupConfig{
+		Domain:    "example.com",
+		Hostname:  "mail.example.com",
+		TLSEmail:  "tls@example.com",
+		DataDir:   filepath.Join(tmp, "var"),
+		ConfigDir: configDir,
+	}
+
+	if err := generateConfig(cfg); err != nil {
+		t.Fatalf("generateConfig: %v", err)
+	}
+	if !cfg.UseExisting {
+		t.Error("UseExisting = false, want true when config.yaml exists")
+	}
+
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(existing) {
+		t.Errorf("existing config was overwritten: %q", got)
+	}
+}
+
+// TestSelfExe_ReturnsAbsolutePath ensures the helper that replaces the broken
+// `exec.Command("mailserver", ...)` lookups returns a usable absolute path.
+func TestSelfExe_ReturnsAbsolutePath(t *testing.T) {
+	got, err := selfExe()
+	if err != nil {
+		t.Fatalf("selfExe: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("selfExe = %q, want absolute path", got)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("selfExe path %q does not exist: %v", got, err)
+	}
+}

--- a/internal/setup/setup_generate_test.go
+++ b/internal/setup/setup_generate_test.go
@@ -3,8 +3,10 @@ package setup
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/fenilsonani/email-server/internal/auth"
 	"github.com/fenilsonani/email-server/internal/config"
 )
 
@@ -131,6 +133,32 @@ func TestGenerateConfig_KeepsExistingConfig(t *testing.T) {
 	}
 	if string(got) != string(existing) {
 		t.Errorf("existing config was overwritten: %q", got)
+	}
+}
+
+// TestAdminPasswordHash_VerifiesViaAuthPackage guards against a regression of
+// the algorithm-mismatch bug flagged on PR #47: setup used bcrypt while
+// internal/auth.VerifyPassword only accepts argon2id, leaving the admin user
+// unable to authenticate. The wizard's hash must round-trip through the same
+// verifier the runtime uses, otherwise `mailserver setup` silently produces a
+// broken admin account.
+func TestAdminPasswordHash_VerifiesViaAuthPackage(t *testing.T) {
+	const plain = "correct horse battery staple"
+
+	hash, err := auth.HashPassword(plain)
+	if err != nil {
+		t.Fatalf("auth.HashPassword: %v", err)
+	}
+
+	if !strings.HasPrefix(hash, "$argon2id$") {
+		t.Fatalf("hash prefix = %q, want $argon2id$ (a bcrypt hash like $2a$ would be silently rejected by VerifyPassword)", hash[:min(len(hash), 12)])
+	}
+
+	if !auth.VerifyPassword(plain, hash) {
+		t.Fatal("auth.VerifyPassword rejected hash produced by auth.HashPassword — algorithm mismatch")
+	}
+	if auth.VerifyPassword("wrong", hash) {
+		t.Fatal("auth.VerifyPassword accepted wrong password")
 	}
 }
 


### PR DESCRIPTION
## Summary
- fixes the chain of bugs reported in #46 that made `sudo ./mailserver setup` unable to complete on a fresh debian box
- adds CLI flags the wizard depends on (`user add --password-hash` / `--admin`, top-level `--version`)
- adds a roundtrip test that runs `generateConfig` and pipes its output back through `config.Load`, so a future schema drift in either side fails CI loudly

## What was broken (per #46)
- `exec.Command("mailserver", ...)` lookups failed under `sudo` because `secure_path` strips the build dir → step 5/8 died with `executable file not found in $PATH`
- after manually copying the binary, step 5 hit `'domains[0]' expected a map or struct, got "string"` because the wizard wrote `domains` as plain strings while `config.Domains` is `[]DomainConfig`
- `user add` was invoked with flags that didn't exist (`--password-hash`, `--admin`)
- the systemd unit pointed at `/usr/local/bin/mailserver` but nothing copied the binary there
- TLS questionnaire answers were silently dropped because the wizard wrote `auto_cert` / `acme_email` / `acme_cache_dir` instead of the schema's `auto_tls` / `email` / `cache_dir`
- bogus top-level `dkim:` block (no such field) silently ignored; the per-domain key was orphaned
- post-success message printed `mailserver dkim show --domain <d>` but `dkim show` is positional only

## Changes
- `internal/setup/setup.go`: `selfExe()` helper, structured `domains`, correct TLS keys, drop bogus `dkim:` block, chown DKIM subtree to the mailserver user, new `installBinary` step, `verifyService` checks `systemctl is-active` first, fix dkim show usage in printSuccess
- `cmd/mailserver/main.go`: cobra `Version` so `--version` works; `user add` accepts optional positional password or `--password-hash`, plus `--admin` (writes existing `is_admin` column)
- `README.md`: quick start now uses `sudo ./mailserver preflight/setup` and notes the wizard self-installs to `/usr/local/bin/mailserver`
- `internal/setup/setup_generate_test.go`: roundtrip + idempotency + selfExe tests

## Out of scope
macOS / launchd support — the wizard still requires systemd. Tracked as a follow-up: #48.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` (full suite green)
- [x] regressed each fix individually and confirmed the new roundtrip test fails with the exact `'domains[0]'` error from #46 when domains-as-strings is reintroduced, and with `TLS.AutoTLS = false, want true` when the TLS keys regress
- [ ] end-to-end run of `sudo ./mailserver setup` on a clean debian VM (server was unreachable when I tried, will run before merge)

Refs #46 (leaving the issue open after merge).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fenilsonani/email-server/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible version command.
  * `user add` accepts pre-hashed passwords and an admin flag.
  * Setup wizard now installs the server binary, runs migrations, generates DKIM keys, and verifies service health with clearer diagnostics.

* **Documentation**
  * Quick Start updated with step-by-step setup wizard instructions.

* **Tests**
  * Added tests covering setup/config generation and password hashing verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
